### PR TITLE
Fix British spelling in comments

### DIFF
--- a/processor/nil.go
+++ b/processor/nil.go
@@ -16,13 +16,13 @@ type Nil struct {
 	Duration time.Duration
 
 	// MarkCancelled controls whether items should be marked with ctx.Err()
-	// when the context is cancelled during processing.
+	// when the context is canceled during processing.
 	// If false, items are returned unchanged on cancellation.
 	MarkCancelled bool
 }
 
 // Process implements the Processor interface by waiting for the specified duration
-// and returning the items unchanged, unless cancelled.
+// and returning the items unchanged, unless canceled.
 func (p *Nil) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
 	if len(items) == 0 || p.Duration <= 0 {
 		return items, nil
@@ -35,7 +35,7 @@ func (p *Nil) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, 
 	case <-timer.C:
 		// Duration complete, return items unchanged
 	case <-ctx.Done():
-		// Context cancelled
+		// Context canceled
 		if p.MarkCancelled {
 			for _, item := range items {
 				item.Error = ctx.Err()

--- a/processor/nil_test.go
+++ b/processor/nil_test.go
@@ -156,7 +156,7 @@ func TestNil_Process(t *testing.T) {
 	})
 
 	t.Run("respects MarkCancelled=false setting", func(t *testing.T) {
-		// Setup - this time don't mark items as cancelled
+		// Setup - this time don't mark items as canceled
 		processor := &Nil{
 			Duration:      1 * time.Second,
 			MarkCancelled: false,
@@ -166,7 +166,7 @@ func TestNil_Process(t *testing.T) {
 			{ID: 1, Data: "test"},
 		}
 
-		// Execute with cancelled context
+		// Execute with canceled context
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately
 

--- a/source/channel.go
+++ b/source/channel.go
@@ -18,7 +18,7 @@ type Channel struct {
 // to the output channel until Input is closed or context is canceled.
 //
 // The returned channels are always created (never nil) and always closed properly
-// when the source is done providing data or context is cancelled.
+// when the source is done providing data or context is canceled.
 func (s *Channel) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
 	bufSize := 100
 	if s.BufferSize > 0 {

--- a/source/error.go
+++ b/source/error.go
@@ -19,7 +19,7 @@ type Error struct {
 // to the error channel until Errs is closed or context is canceled.
 //
 // The returned channels are always created (never nil) and always closed properly
-// when the source is done providing errors or context is cancelled.
+// when the source is done providing errors or context is canceled.
 // The output channel is always empty, as this source produces only errors.
 func (s *Error) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
 	out := make(chan interface{})

--- a/source/nil.go
+++ b/source/nil.go
@@ -18,7 +18,7 @@ type Nil struct {
 // It never emits any data or errors.
 //
 // The returned channels are always created (never nil) and always closed properly
-// when the source completes waiting or context is cancelled.
+// when the source completes waiting or context is canceled.
 func (s *Nil) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
 	out := make(chan interface{})
 	errs := make(chan error)
@@ -39,7 +39,7 @@ func (s *Nil) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
 		case <-timer.C:
 			// Duration complete
 		case <-ctx.Done():
-			// Context cancelled
+			// Context canceled
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- use American English spelling for canceled comments

## Testing
- `go test ./...`
