### PR TITLE
Define default buffer constants

### DIFF
--- a/source/channel.go
+++ b/source/channel.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+const defaultChannelBuffer = 100
+
 // Channel is a Source that reads from an input channel until it's closed.
 // It simplifies using an existing channel as a data source for batch processing.
 type Channel struct {
@@ -20,7 +22,7 @@ type Channel struct {
 // The returned channels are always created (never nil) and always closed properly
 // when the source is done providing data or context is canceled.
 func (s *Channel) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	bufSize := 100
+	bufSize := defaultChannelBuffer
 	if s.BufferSize > 0 {
 		bufSize = s.BufferSize
 	}

--- a/source/error.go
+++ b/source/error.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+const defaultErrorBuffer = 10
+
 // Error is a Source that only emits errors from a channel and provides no data.
 // It is useful for testing error handling in batch processing pipelines and
 // for representing error-only streams.
@@ -24,7 +26,7 @@ type Error struct {
 func (s *Error) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
 	out := make(chan interface{})
 
-	bufSize := 10
+	bufSize := defaultErrorBuffer
 	if s.BufferSize > 0 {
 		bufSize = s.BufferSize
 	}


### PR DESCRIPTION
## Summary
- add `defaultChannelBuffer` and use it in Channel
- add `defaultErrorBuffer` and use it in Error

## Testing
- `go test ./...`
