### PR TITLE
Add result collector example

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ func main() {
 10
 ```
 
+## Examples
+
+GoBatch ships with several runnable examples located in the `batch` directory.
+Each example can be executed with `go test ./batch -run Example`.
+
+- `example_test.go` – basic usage with two processors.
+- `example_simple_processor_test.go` – implementing a custom processor.
+- `example_processor_chain_test.go` – chaining multiple processors together.
+- `example_error_handling_test.go` – capturing and reporting errors.
+- `example_custom_config_test.go` – custom dynamic configuration logic.
+- `example_dynamic_config_test.go` – adjusting configuration at runtime.
+- `example_collect_results_test.go` – using `processor.Collect` to gather results.
+
 ## Configuration
 
 GoBatch supports flexible configuration through the `Config` interface, which defines how batches are formed based on size and timing rules.

--- a/batch/example_collect_results_test.go
+++ b/batch/example_collect_results_test.go
@@ -1,0 +1,39 @@
+package batch_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MasterOfBinary/gobatch/batch"
+	"github.com/MasterOfBinary/gobatch/processor"
+	"github.com/MasterOfBinary/gobatch/source"
+)
+
+func Example_collectResults() {
+	b := batch.New(batch.NewConstantConfig(&batch.ConfigValues{MinItems: 5, MaxItems: 5}))
+
+	ch := make(chan interface{}, 5)
+	for i := 1; i <= 5; i++ {
+		ch <- i
+	}
+	close(ch)
+
+	src := &source.Channel{Input: ch}
+	doubleProc := &processor.Transform{Func: func(data interface{}) (interface{}, error) {
+		if v, ok := data.(int); ok {
+			return v * 2, nil
+		}
+		return data, nil
+	}}
+
+	collect := &processor.Collect{}
+	ctx := context.Background()
+
+	errs := batch.RunBatchAndWait(ctx, b, src, doubleProc, collect)
+
+	fmt.Println(collect.Data)
+	fmt.Println("errors:", len(errs))
+	// Output:
+	// [2 4 6 8 10]
+	// errors: 0
+}

--- a/processor/collect.go
+++ b/processor/collect.go
@@ -1,0 +1,33 @@
+package processor
+
+import (
+	"context"
+	"sync"
+
+	"github.com/MasterOfBinary/gobatch/batch"
+)
+
+// Collect is a processor that gathers item data into the Data slice.
+//
+// It is useful for capturing results from a processing pipeline.
+// Collect is safe for concurrent use because Process may be invoked
+// by multiple goroutines.
+type Collect struct {
+	mu   sync.Mutex
+	Data []interface{}
+}
+
+// Process appends each item's Data to the Data slice.
+func (c *Collect) Process(_ context.Context, items []*batch.Item) ([]*batch.Item, error) {
+	if len(items) == 0 {
+		return items, nil
+	}
+
+	c.mu.Lock()
+	for _, item := range items {
+		c.Data = append(c.Data, item.Data)
+	}
+	c.mu.Unlock()
+
+	return items, nil
+}

--- a/processor/collect_test.go
+++ b/processor/collect_test.go
@@ -1,0 +1,60 @@
+package processor
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/MasterOfBinary/gobatch/batch"
+)
+
+func TestCollect_Process(t *testing.T) {
+	t.Run("appends item data", func(t *testing.T) {
+		c := &Collect{}
+		items := []*batch.Item{
+			{ID: 1, Data: "a"},
+			{ID: 2, Data: "b"},
+		}
+		ctx := context.Background()
+		_, err := c.Process(ctx, items)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(c.Data) != 2 {
+			t.Fatalf("expected 2 items collected, got %d", len(c.Data))
+		}
+		if c.Data[0] != "a" || c.Data[1] != "b" {
+			t.Fatalf("unexpected collected data: %v", c.Data)
+		}
+	})
+
+	t.Run("safe for concurrent use", func(t *testing.T) {
+		c := &Collect{}
+		wg := sync.WaitGroup{}
+		ctx := context.Background()
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				items := []*batch.Item{{ID: uint64(id), Data: id}}
+				c.Process(ctx, items)
+			}(i)
+		}
+		wg.Wait()
+		if len(c.Data) != 5 {
+			t.Fatalf("expected 5 items collected, got %d", len(c.Data))
+		}
+	})
+}
+
+func TestCollect_EmptySlice(t *testing.T) {
+	c := &Collect{}
+	ctx := context.Background()
+	_, err := c.Process(ctx, []*batch.Item{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(c.Data) != 0 {
+		t.Fatalf("expected no data collected, got %d", len(c.Data))
+	}
+}

--- a/processor/doc.go
+++ b/processor/doc.go
@@ -5,6 +5,7 @@
 // - Filter: For filtering items based on custom predicates
 // - Nil: For testing timing behavior without modifying items
 // - Transform: For transforming item data values
+// - Collect: For capturing processed item data in a slice
 //
 // Each processor implementation follows a consistent error handling pattern and
 // respects context cancellation.


### PR DESCRIPTION
## Summary
- add `processor.Collect` tests
- document available examples in README
- add `example_collect_results_test.go` demonstrating result collection
- note `Collect` in processor docs

Fixes #5

## Testing
- `go test ./...`
