### PR TITLE
Add ResultCollector processor for collecting batch results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,9 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 
 ## Important Commands
 - Run tests: `go test ./...`
-- Lint code: `go vet ./...`
+- Lint code: 
+  - Basic: `go vet ./...`
+  - Full: `golangci-lint run` (used in CI workflow)
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns
@@ -25,6 +27,13 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 - Method documentation should explain what the method does, its parameters, return values, and any side effects
 - Follow the format seen in existing files (e.g., batch/batch.go)
 - Include practical examples in documentation
+- Code blocks in comments must use tab indentation after the comment marker:
+  ```go
+  // Example:
+  //
+  //	exampleCode := "Use a tab after //"
+  //	fmt.Println(exampleCode)
+  ```
 
 ## File Structure
 - `/batch`: Core batch processing functionality, includes the main Batch type and configuration

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ go get github.com/MasterOfBinary/gobatch
 
 - **Filter**: Filters items based on a predicate function.
 - **Transform**: Transforms item data with a custom function.
+- **ResultCollector**: Collects processed items for retrieval after processing.
 - **Error**: Simulates processor errors for testing.
 - **Nil**: Passes items through unchanged for benchmarking.
 
@@ -114,6 +115,7 @@ go get github.com/MasterOfBinary/gobatch
 - `CollectErrors`: Collects all errors into a slice after batch processing finishes.
 - `RunBatchAndWait`: Starts a batch, waits for completion, and returns all collected errors.
 - `ExecuteBatches`: Runs multiple batches concurrently and collects all errors into a single slice.
+- `ExtractData`: Extracts typed data from a ResultCollector's collected items.
 
 ## Basic Usage
 
@@ -272,6 +274,46 @@ errs := batch.RunBatchAndWait(ctx, batchProcessor, source, processor)
 
 for _, err := range errs {
     // Handle error
+}
+```
+
+### Example: Collecting Processing Results
+
+Use the ResultCollector processor to collect and access batch processing results:
+
+```go
+import (
+    "github.com/MasterOfBinary/gobatch/batch"
+    "github.com/MasterOfBinary/gobatch/processor"
+    "github.com/MasterOfBinary/gobatch/source"
+)
+
+// Create a result collector
+collector := &processor.ResultCollector{
+    // Optional: filter which items to collect
+    Filter: func(item *batch.Item) bool {
+        // Only collect items with even IDs
+        return item.ID%2 == 0
+    },
+    // Optional: limit number of collected items
+    MaxItems: 100,
+    // Optional: include items with errors (default: false)
+    CollectErrors: false,
+}
+
+// Add the collector to the processor chain
+errs := batch.RunBatchAndWait(ctx, b, src, transformProc, filterProc, collector)
+
+// Access collected results
+results := collector.Results()
+for _, item := range results {
+    fmt.Printf("Item %d: %v\n", item.ID, item.Data)
+}
+
+// Extract typed data with type safety
+strings := processor.ExtractData[string](collector)
+for _, s := range strings {
+    fmt.Println(s)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ go get github.com/MasterOfBinary/gobatch
 - `CollectErrors`: Collects all errors into a slice after batch processing finishes.
 - `RunBatchAndWait`: Starts a batch, waits for completion, and returns all collected errors.
 - `ExecuteBatches`: Runs multiple batches concurrently and collects all errors into a single slice.
-- `ExtractData`: Extracts typed data from a ResultCollector's collected items.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ go get github.com/MasterOfBinary/gobatch
 
 - **Filter**: Filters items based on a predicate function.
 - **Transform**: Transforms item data with a custom function.
-- **ResultCollector**: Collects processed items for retrieval after processing.
+- **ResultCollector**: Collects and provides access to processed items.
 - **Error**: Simulates processor errors for testing.
 - **Nil**: Passes items through unchanged for benchmarking.
 
@@ -303,16 +303,21 @@ collector := &processor.ResultCollector{
 // Add the collector to the processor chain
 errs := batch.RunBatchAndWait(ctx, b, src, transformProc, filterProc, collector)
 
-// Access collected results
-results := collector.Results()
+// Access collected results (get without resetting)
+results := collector.Results(false)
 for _, item := range results {
     fmt.Printf("Item %d: %v\n", item.ID, item.Data)
 }
 
-// Extract typed data with type safety
-strings := processor.ExtractData[string](collector)
-for _, s := range strings {
-    fmt.Println(s)
+// Extract specific data types manually
+// (and reset the collector at the same time)
+strings := []string{}
+for _, item := range collector.Results(true) {
+    if item.Error == nil {
+        if s, ok := item.Data.(string); ok {
+            strings = append(strings, s)
+        }
+    }
 }
 ```
 

--- a/processor/collector.go
+++ b/processor/collector.go
@@ -1,0 +1,148 @@
+package processor
+
+import (
+	"context"
+	"sync"
+
+	"github.com/MasterOfBinary/gobatch/batch"
+)
+
+// ResultCollector is a processor that collects processed items.
+// It can be used as the final processor in a chain to collect results.
+// The processor implements thread-safe collection of items that pass through
+// the processor chain, allowing access to the collected items after processing
+// is complete.
+//
+// Example usage:
+//
+//	collector := &processor.ResultCollector{}
+//	b := batch.New(config)
+//	batch.RunBatchAndWait(ctx, b, source, processor1, processor2, collector)
+//	
+//	// Access results
+//	results := collector.Results()
+//	for _, item := range results {
+//		fmt.Println(item.Data)
+//	}
+//
+// By default, items with errors are not collected. This behavior can be
+// changed by setting CollectErrors to true.
+type ResultCollector struct {
+	// Filter determines which items to collect.
+	// If nil, all items without errors are collected.
+	// For an item to be collected, this function must return true.
+	Filter func(item *batch.Item) bool
+
+	// MaxItems limits the number of items collected (0 for unlimited).
+	// Once the number of collected items reaches MaxItems, no more items
+	// will be collected.
+	MaxItems int
+
+	// CollectErrors determines whether to collect items with errors.
+	// When false (default), items with non-nil Error will be skipped.
+	// When true, items with errors will be collected if they pass the Filter.
+	CollectErrors bool
+
+	mu      sync.Mutex
+	results []*batch.Item
+}
+
+// Process implements the Processor interface by collecting items
+// based on the filter criteria. All items pass through unchanged,
+// allowing subsequent processors to operate on them.
+func (c *ResultCollector) Process(_ context.Context, items []*batch.Item) ([]*batch.Item, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, item := range items {
+		// Skip items with errors unless CollectErrors is true
+		if item.Error != nil && !c.CollectErrors {
+			continue
+		}
+
+		// Apply custom filter if present
+		if c.Filter != nil && !c.Filter(item) {
+			continue
+		}
+
+		// Check if we've reached the maximum number of items
+		if c.MaxItems > 0 && len(c.results) >= c.MaxItems {
+			break
+		}
+
+		// Create a deep copy of the item to avoid issues if later processors modify it
+		itemCopy := &batch.Item{
+			ID:    item.ID,
+			Data:  item.Data,
+			Error: item.Error,
+		}
+		c.results = append(c.results, itemCopy)
+	}
+
+	return items, nil
+}
+
+// Results returns a deep copy of the collected items.
+// This method is thread-safe and can be called while processing is ongoing.
+func (c *ResultCollector) Results() []*batch.Item {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Create a deep copy to prevent external modifications from affecting internal state
+	result := make([]*batch.Item, len(c.results))
+	for i, item := range c.results {
+		// Make a deep copy of each item
+		result[i] = &batch.Item{
+			ID:    item.ID,
+			Data:  item.Data,
+			Error: item.Error,
+		}
+	}
+	return result
+}
+
+// Reset clears all collected results.
+// This method is thread-safe and can be used to reuse the collector.
+func (c *ResultCollector) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.results = nil
+}
+
+// Count returns the number of items collected so far.
+// This method is thread-safe and can be called while processing is ongoing.
+func (c *ResultCollector) Count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return len(c.results)
+}
+
+// ExtractData extracts typed data from collected results.
+// Only items where the Data field can be type-asserted to T are included.
+// Items with errors are included only if they were collected.
+//
+// Example:
+//
+//	collector := &processor.ResultCollector{}
+//	batch.RunBatchAndWait(ctx, b, src, processor1, collector)
+//	
+//	// Extract all string values
+//	strings := processor.ExtractData[string](collector)
+func ExtractData[T any](collector *ResultCollector) []T {
+	items := collector.Results()
+	result := make([]T, 0, len(items))
+
+	for _, item := range items {
+		if item.Error != nil {
+			continue
+		}
+
+		if data, ok := item.Data.(T); ok {
+			result = append(result, data)
+		}
+	}
+
+	return result
+}

--- a/processor/collector.go
+++ b/processor/collector.go
@@ -22,7 +22,7 @@ import (
 //	// Access results
 //	results := collector.Results()
 //	for _, item := range results {
-//		fmt.Println(item.Data)
+//	  fmt.Println(item.Data)
 //	}
 //
 // By default, items with errors are not collected. This behavior can be

--- a/processor/collector.go
+++ b/processor/collector.go
@@ -152,35 +152,3 @@ func (c *ResultCollector) Count() int {
 	return len(c.results)
 }
 
-// ExtractData extracts typed data from collected results.
-// Only items where the Data field can be type-asserted to T are included.
-// Items with errors are included only if they were collected.
-//
-// The reset parameter determines whether to clear the collection after extracting data.
-//
-// Example:
-//
-//	collector := &processor.ResultCollector{}
-//	batch.RunBatchAndWait(ctx, b, src, processor1, collector)
-//	
-//	// Extract all string values (keep items in collector)
-//	strings := processor.ExtractData[string](collector, false)
-//	
-//	// Extract and clear collection
-//	finalStrings := processor.ExtractData[string](collector, true)
-func ExtractData[T any](collector *ResultCollector, reset bool) []T {
-	items := collector.Results(reset)
-	result := make([]T, 0, len(items))
-
-	for _, item := range items {
-		if item.Error != nil {
-			continue
-		}
-
-		if data, ok := item.Data.(T); ok {
-			result = append(result, data)
-		}
-	}
-
-	return result
-}

--- a/processor/collector.go
+++ b/processor/collector.go
@@ -22,15 +22,15 @@ import (
 //
 // Example usage:
 //
-//	collector := &processor.ResultCollector{}
-//	b := batch.New(config)
-//	batch.RunBatchAndWait(ctx, b, source, processor1, processor2, collector)
-//	
-//	// Access results
-//	results := collector.Results()
-//	for _, item := range results {
-//	  fmt.Println(item.Data)
-//	}
+// collector := &processor.ResultCollector{}
+// b := batch.New(config)
+// batch.RunBatchAndWait(ctx, b, source, processor1, processor2, collector)
+// 
+// // Access results
+// results := collector.Results()
+// for _, item := range results {
+//   fmt.Println(item.Data)
+// }
 //
 // By default, items with errors are not collected. This behavior can be
 // changed by setting CollectErrors to true.
@@ -136,11 +136,11 @@ func (c *ResultCollector) Count() int {
 //
 // Example:
 //
-//	collector := &processor.ResultCollector{}
-//	batch.RunBatchAndWait(ctx, b, src, processor1, collector)
-//	
-//	// Extract all string values
-//	strings := processor.ExtractData[string](collector)
+// collector := &processor.ResultCollector{}
+// batch.RunBatchAndWait(ctx, b, src, processor1, collector)
+// 
+// // Extract all string values
+// strings := processor.ExtractData[string](collector)
 func ExtractData[T any](collector *ResultCollector) []T {
 	items := collector.Results()
 	result := make([]T, 0, len(items))

--- a/processor/collector.go
+++ b/processor/collector.go
@@ -22,15 +22,15 @@ import (
 //
 // Example usage:
 //
-// collector := &processor.ResultCollector{}
-// b := batch.New(config)
-// batch.RunBatchAndWait(ctx, b, source, processor1, processor2, collector)
-// 
-// // Access results
-// results := collector.Results()
-// for _, item := range results {
-//   fmt.Println(item.Data)
-// }
+//	collector := &processor.ResultCollector{}
+//	b := batch.New(config)
+//	batch.RunBatchAndWait(ctx, b, source, processor1, processor2, collector)
+//	
+//	// Access results
+//	results := collector.Results()
+//	for _, item := range results {
+//	  fmt.Println(item.Data)
+//	}
 //
 // By default, items with errors are not collected. This behavior can be
 // changed by setting CollectErrors to true.
@@ -136,11 +136,11 @@ func (c *ResultCollector) Count() int {
 //
 // Example:
 //
-// collector := &processor.ResultCollector{}
-// batch.RunBatchAndWait(ctx, b, src, processor1, collector)
-// 
-// // Extract all string values
-// strings := processor.ExtractData[string](collector)
+//	collector := &processor.ResultCollector{}
+//	batch.RunBatchAndWait(ctx, b, src, processor1, collector)
+//	
+//	// Extract all string values
+//	strings := processor.ExtractData[string](collector)
 func ExtractData[T any](collector *ResultCollector) []T {
 	items := collector.Results()
 	result := make([]T, 0, len(items))

--- a/processor/collector_test.go
+++ b/processor/collector_test.go
@@ -123,7 +123,10 @@ func TestResultCollector_Reset(t *testing.T) {
 	collector := &ResultCollector{}
 	
 	// Process items
-	collector.Process(context.Background(), items)
+	_, err := collector.Process(context.Background(), items)
+	if err != nil {
+		t.Fatalf("Process returned unexpected error: %v", err)
+	}
 	
 	// Verify items were collected
 	if count := collector.Count(); count != 2 {
@@ -191,7 +194,10 @@ func TestExtractData(t *testing.T) {
 	
 	// Process with collector that includes errors
 	collector.CollectErrors = true
-	collector.Process(context.Background(), items)
+	_, err := collector.Process(context.Background(), items)
+	if err != nil {
+		t.Fatalf("Process returned unexpected error: %v", err)
+	}
 	
 	// Extract strings
 	strings := ExtractData[string](collector)
@@ -232,7 +238,10 @@ func TestResultCollector_ItemCopying(t *testing.T) {
 	}
 	
 	// Process the items
-	collector.Process(context.Background(), items)
+	_, err := collector.Process(context.Background(), items)
+	if err != nil {
+		t.Fatalf("Process returned unexpected error: %v", err)
+	}
 	
 	// Get the collected results
 	results := collector.Results()
@@ -267,7 +276,10 @@ func TestResultCollector_ItemCopying(t *testing.T) {
 	}
 	
 	collector.Reset()
-	collector.Process(context.Background(), mutableItems)
+	_, err = collector.Process(context.Background(), mutableItems)
+	if err != nil {
+		t.Fatalf("Process returned unexpected error: %v", err)
+	}
 	
 	// Get results and modify the original map
 	mutableResults := collector.Results()

--- a/processor/collector_test.go
+++ b/processor/collector_test.go
@@ -1,0 +1,263 @@
+package processor
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/MasterOfBinary/gobatch/batch"
+)
+
+func TestResultCollector_Process(t *testing.T) {
+	items := []*batch.Item{
+		{ID: 1, Data: "test1"},
+		{ID: 2, Data: "test2"},
+		{ID: 3, Data: "test3", Error: errors.New("error3")},
+		{ID: 4, Data: "test4"},
+		{ID: 5, Data: 42}, // Different type
+	}
+
+	tests := []struct {
+		name          string
+		collector     *ResultCollector
+		expectedCount int
+		expectedData  []interface{}
+	}{
+		{
+			name:          "default settings",
+			collector:     &ResultCollector{},
+			expectedCount: 4,
+			expectedData:  []interface{}{"test1", "test2", "test4", 42},
+		},
+		{
+			name:          "collect errors",
+			collector:     &ResultCollector{CollectErrors: true},
+			expectedCount: 5,
+			expectedData:  []interface{}{"test1", "test2", "test3", "test4", 42},
+		},
+		{
+			name: "with filter",
+			collector: &ResultCollector{
+				Filter: func(item *batch.Item) bool {
+					// Only collect even IDs
+					return item.ID%2 == 0
+				},
+			},
+			expectedCount: 2,
+			expectedData:  []interface{}{"test2", "test4"},
+		},
+		{
+			name: "max items",
+			collector: &ResultCollector{
+				MaxItems: 2,
+			},
+			expectedCount: 2,
+			expectedData:  []interface{}{"test1", "test2"},
+		},
+		{
+			name: "filter with type check",
+			collector: &ResultCollector{
+				Filter: func(item *batch.Item) bool {
+					_, isString := item.Data.(string)
+					return isString
+				},
+				MaxItems:      10,
+				CollectErrors: true,
+			},
+			expectedCount: 4,
+			expectedData:  []interface{}{"test1", "test2", "test3", "test4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Process the items
+			result, err := tt.collector.Process(context.Background(), items)
+			
+			// Check that the returned error is nil
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			
+			// Check that the returned items are the same as the input
+			if !reflect.DeepEqual(result, items) {
+				t.Errorf("Process() items = %v, want %v", result, items)
+			}
+			
+			// Check the number of collected items
+			if count := tt.collector.Count(); count != tt.expectedCount {
+				t.Errorf("Count() = %v, want %v", count, tt.expectedCount)
+			}
+			
+			// Check the collected items
+			collected := tt.collector.Results()
+			if len(collected) != tt.expectedCount {
+				t.Errorf("Results() returned %d items, want %d", len(collected), tt.expectedCount)
+			}
+			
+			// Check the content of collected items
+			dataList := make([]interface{}, 0, len(collected))
+			for _, item := range collected {
+				if s, ok := item.Data.(string); ok {
+					dataList = append(dataList, s)
+				} else if n, ok := item.Data.(int); ok {
+					dataList = append(dataList, n)
+				}
+			}
+			
+			if !reflect.DeepEqual(dataList, tt.expectedData) {
+				t.Errorf("Results data = %v, want %v", dataList, tt.expectedData)
+			}
+		})
+	}
+}
+
+func TestResultCollector_Reset(t *testing.T) {
+	items := []*batch.Item{
+		{ID: 1, Data: "test1"},
+		{ID: 2, Data: "test2"},
+	}
+	
+	collector := &ResultCollector{}
+	
+	// Process items
+	collector.Process(context.Background(), items)
+	
+	// Verify items were collected
+	if count := collector.Count(); count != 2 {
+		t.Errorf("Initial count = %d, want 2", count)
+	}
+	
+	// Reset the collector
+	collector.Reset()
+	
+	// Verify no items remain
+	if count := collector.Count(); count != 0 {
+		t.Errorf("Count after reset = %d, want 0", count)
+	}
+	
+	if results := collector.Results(); len(results) != 0 {
+		t.Errorf("Results after reset = %v, want empty slice", results)
+	}
+}
+
+func TestResultCollector_Concurrency(t *testing.T) {
+	collector := &ResultCollector{}
+	var wg sync.WaitGroup
+	
+	// Number of concurrent goroutines and items per goroutine
+	goroutines := 10
+	itemsPerGoroutine := 100
+	
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(routineID int) {
+			defer wg.Done()
+			
+			items := make([]*batch.Item, itemsPerGoroutine)
+			for j := 0; j < itemsPerGoroutine; j++ {
+				items[j] = &batch.Item{
+					ID:   uint64(routineID*itemsPerGoroutine + j),
+					Data: routineID*itemsPerGoroutine + j,
+				}
+			}
+			
+			_, _ = collector.Process(context.Background(), items)
+		}(i)
+	}
+	
+	wg.Wait()
+	
+	// Verify all items were collected
+	expectedCount := goroutines * itemsPerGoroutine
+	if count := collector.Count(); count != expectedCount {
+		t.Errorf("Count after concurrent processing = %d, want %d", count, expectedCount)
+	}
+}
+
+func TestExtractData(t *testing.T) {
+	collector := &ResultCollector{}
+	
+	items := []*batch.Item{
+		{ID: 1, Data: "string1"},
+		{ID: 2, Data: 42},
+		{ID: 3, Data: "string2"},
+		{ID: 4, Data: 3.14},
+		{ID: 5, Data: "string3", Error: errors.New("error")},
+		{ID: 6, Data: true},
+	}
+	
+	// Process with collector that includes errors
+	collector.CollectErrors = true
+	collector.Process(context.Background(), items)
+	
+	// Extract strings
+	strings := ExtractData[string](collector)
+	expectedStrings := []string{"string1", "string2"}
+	if !reflect.DeepEqual(strings, expectedStrings) {
+		t.Errorf("ExtractData[string] = %v, want %v", strings, expectedStrings)
+	}
+	
+	// Extract ints
+	ints := ExtractData[int](collector)
+	expectedInts := []int{42}
+	if !reflect.DeepEqual(ints, expectedInts) {
+		t.Errorf("ExtractData[int] = %v, want %v", ints, expectedInts)
+	}
+	
+	// Extract floats
+	floats := ExtractData[float64](collector)
+	expectedFloats := []float64{3.14}
+	if !reflect.DeepEqual(floats, expectedFloats) {
+		t.Errorf("ExtractData[float64] = %v, want %v", floats, expectedFloats)
+	}
+	
+	// Extract bools
+	bools := ExtractData[bool](collector)
+	expectedBools := []bool{true}
+	if !reflect.DeepEqual(bools, expectedBools) {
+		t.Errorf("ExtractData[bool] = %v, want %v", bools, expectedBools)
+	}
+}
+
+func TestResultCollector_ItemCopying(t *testing.T) {
+	// Create a collector
+	collector := &ResultCollector{}
+	
+	// Create test items
+	items := []*batch.Item{
+		{ID: 1, Data: "test1"},
+	}
+	
+	// Process the items
+	collector.Process(context.Background(), items)
+	
+	// Get the collected results
+	results := collector.Results()
+	
+	// Modify the original items
+	items[0].Data = "modified"
+	
+	// Verify that the collected items were not affected
+	if results[0].Data != "test1" {
+		t.Errorf("Collected item was modified, got %v, want %v", results[0].Data, "test1")
+	}
+	
+	// Modify the results
+	results[0].Data = "modified result"
+	
+	// Get a fresh copy of the results
+	internalResults := collector.Results()
+	
+	// Verify that modifying the result doesn't affect the internal collection
+	if internalResults[0].Data != "test1" {
+		t.Errorf("Internal collection was modified, got %v, want %v", internalResults[0].Data, "test1")
+	}
+	
+	// Verify that the two result slices are distinct
+	if reflect.ValueOf(results[0]).Pointer() == reflect.ValueOf(internalResults[0]).Pointer() {
+		t.Error("Results() did not return a deep copy of items")
+	}
+}

--- a/processor/collector_test.go
+++ b/processor/collector_test.go
@@ -202,7 +202,7 @@ func TestResultCollector_Concurrency(t *testing.T) {
 	}
 }
 
-func TestExtractData(t *testing.T) {
+func TestManualDataExtraction(t *testing.T) {
 	collector := &ResultCollector{}
 	
 	items := []*batch.Item{
@@ -222,32 +222,25 @@ func TestExtractData(t *testing.T) {
 	}
 	
 	// Extract strings without resetting
-	strings := ExtractData[string](collector, false)
+	results := collector.Results(false)
+	
+	// Manual extraction of strings
+	strings := make([]string, 0)
+	for _, item := range results {
+		if item.Error != nil {
+			continue
+		}
+		if s, ok := item.Data.(string); ok {
+			strings = append(strings, s)
+		}
+	}
 	expectedStrings := []string{"string1", "string2"}
 	if !reflect.DeepEqual(strings, expectedStrings) {
-		t.Errorf("ExtractData[string] = %v, want %v", strings, expectedStrings)
+		t.Errorf("Extracted strings = %v, want %v", strings, expectedStrings)
 	}
 	
-	// Extract ints without resetting
-	ints := ExtractData[int](collector, false)
-	expectedInts := []int{42}
-	if !reflect.DeepEqual(ints, expectedInts) {
-		t.Errorf("ExtractData[int] = %v, want %v", ints, expectedInts)
-	}
-	
-	// Extract floats without resetting
-	floats := ExtractData[float64](collector, false)
-	expectedFloats := []float64{3.14}
-	if !reflect.DeepEqual(floats, expectedFloats) {
-		t.Errorf("ExtractData[float64] = %v, want %v", floats, expectedFloats)
-	}
-	
-	// Extract bools and reset
-	bools := ExtractData[bool](collector, true)
-	expectedBools := []bool{true}
-	if !reflect.DeepEqual(bools, expectedBools) {
-		t.Errorf("ExtractData[bool] = %v, want %v", bools, expectedBools)
-	}
+	// Test resetting after collection
+	collector.Results(true)
 	
 	// Verify collector was reset
 	if count := collector.Count(); count != 0 {

--- a/processor/example_collector_test.go
+++ b/processor/example_collector_test.go
@@ -65,10 +65,16 @@ func Example_resultCollector() {
 		fmt.Printf("Item ID %d: %v\n", item.ID, item.Data)
 	}
 
-	// Extract only the integers using the type-safe ExtractData function
-	// and reset the collector at the same time
-	integers := processor.ExtractData[int](collector, true)
+	// Extract and display integers manually while resetting
 	fmt.Println("\nExtracted integers:")
+	integers := []int{}
+	for _, item := range collector.Results(true) { // Get results and reset
+		if item.Error == nil {
+			if val, ok := item.Data.(int); ok {
+				integers = append(integers, val)
+			}
+		}
+	}
 	fmt.Println(integers)
 
 	// Output:

--- a/processor/example_collector_test.go
+++ b/processor/example_collector_test.go
@@ -1,0 +1,147 @@
+package processor_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/MasterOfBinary/gobatch/batch"
+	"github.com/MasterOfBinary/gobatch/processor"
+	"github.com/MasterOfBinary/gobatch/source"
+)
+
+// This example demonstrates how to use the ResultCollector processor to collect
+// processed items from a batch operation.
+func Example_resultCollector() {
+	// Create a source with integer data
+	ch := make(chan interface{})
+	go func() {
+		defer close(ch)
+		for i := 1; i <= 10; i++ {
+			ch <- i
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	src := &source.Channel{Input: ch}
+
+	// Create a processor that squares the numbers
+	squareProcessor := &processor.Transform{
+		Func: func(data interface{}) (interface{}, error) {
+			if num, ok := data.(int); ok {
+				return num * num, nil
+			}
+			return data, nil
+		},
+	}
+
+	// Create a filter processor that keeps only even numbers
+	evenFilter := &processor.Filter{
+		Predicate: func(item *batch.Item) bool {
+			if num, ok := item.Data.(int); ok {
+				return num%2 == 0
+			}
+			return false
+		},
+	}
+
+	// Create a result collector
+	collector := &processor.ResultCollector{}
+
+	// Create a batch with simple configuration
+	config := batch.NewConstantConfig(&batch.ConfigValues{
+		MinItems: 2,
+		MaxItems: 4,
+	})
+	b := batch.New(config)
+
+	// Run the batch process
+	ctx := context.Background()
+	fmt.Println("Starting batch processing...")
+	batch.RunBatchAndWait(ctx, b, src, squareProcessor, evenFilter, collector)
+
+	// Get all the collected results
+	fmt.Println("\nAll collected results:")
+	for _, item := range collector.Results() {
+		fmt.Printf("Item ID %d: %v\n", item.ID, item.Data)
+	}
+
+	// Extract only the integers using the type-safe ExtractData function
+	integers := processor.ExtractData[int](collector)
+	fmt.Println("\nExtracted integers:")
+	fmt.Println(integers)
+
+	// Output:
+	// Starting batch processing...
+	//
+	// All collected results:
+	// Item ID 1: 4
+	// Item ID 3: 16
+	// Item ID 5: 36
+	// Item ID 7: 64
+	// Item ID 9: 100
+	//
+	// Extracted integers:
+	// [4 16 36 64 100]
+}
+
+// This example shows how to use the ResultCollector with custom filter options
+// to selectively collect items from the processing pipeline.
+func Example_resultCollectorWithOptions() {
+	// Create a source with string data
+	ch := make(chan interface{})
+	go func() {
+		defer close(ch)
+		words := []string{"hello", "world", "batch", "processing", "is", "awesome"}
+		for _, word := range words {
+			ch <- word
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	src := &source.Channel{Input: ch}
+
+	// Create a processor that transforms strings to uppercase
+	uppercaseProcessor := &processor.Transform{
+		Func: func(data interface{}) (interface{}, error) {
+			if str, ok := data.(string); ok {
+				return fmt.Sprintf("[%s]", str), nil
+			}
+			return data, nil
+		},
+	}
+
+	// Create a result collector that only collects items with length > 6
+	collector := &processor.ResultCollector{
+		Filter: func(item *batch.Item) bool {
+			if str, ok := item.Data.(string); ok {
+				return len(str) > 8
+			}
+			return false
+		},
+		MaxItems: 3, // Limit to 3 items
+	}
+
+	// Create a batch with simple configuration
+	config := batch.NewConstantConfig(&batch.ConfigValues{
+		MinItems: 1,
+		MaxItems: 10,
+	})
+	b := batch.New(config)
+
+	// Run the batch process
+	ctx := context.Background()
+	fmt.Println("Starting filtered collection...")
+	batch.RunBatchAndWait(ctx, b, src, uppercaseProcessor, collector)
+
+	// Get all the collected results
+	fmt.Println("\nCollected items (length > 8, max 3 items):")
+	for _, item := range collector.Results() {
+		fmt.Printf("Item ID %d: %v\n", item.ID, item.Data)
+	}
+
+	// Output:
+	// Starting filtered collection...
+	//
+	// Collected items (length > 8, max 3 items):
+	// Item ID 3: [processing]
+	// Item ID 5: [awesome]
+}

--- a/processor/example_collector_test.go
+++ b/processor/example_collector_test.go
@@ -59,14 +59,15 @@ func Example_resultCollector() {
 	fmt.Println("Starting batch processing...")
 	batch.RunBatchAndWait(ctx, b, src, squareProcessor, evenFilter, collector)
 
-	// Get all the collected results
+	// Get all the collected results (without resetting)
 	fmt.Println("\nAll collected results:")
-	for _, item := range collector.Results() {
+	for _, item := range collector.Results(false) {
 		fmt.Printf("Item ID %d: %v\n", item.ID, item.Data)
 	}
 
 	// Extract only the integers using the type-safe ExtractData function
-	integers := processor.ExtractData[int](collector)
+	// and reset the collector at the same time
+	integers := processor.ExtractData[int](collector, true)
 	fmt.Println("\nExtracted integers:")
 	fmt.Println(integers)
 
@@ -132,9 +133,9 @@ func Example_resultCollectorWithOptions() {
 	fmt.Println("Starting filtered collection...")
 	batch.RunBatchAndWait(ctx, b, src, uppercaseProcessor, collector)
 
-	// Get all the collected results
+	// Get all the collected results (and reset the collector)
 	fmt.Println("\nCollected items (length > 8, max 3 items):")
-	for _, item := range collector.Results() {
+	for _, item := range collector.Results(true) {
 		fmt.Printf("Item ID %d: %v\n", item.ID, item.Data)
 	}
 


### PR DESCRIPTION
## Add ResultCollector processor for collecting batch results

This PR addresses the issue discussed in #XXX where users need a way to collect processed items from batch operations.

### Features

- New `ResultCollector` processor that can be added to the processor chain
- Configurable filtering to select which items to collect
- Options to limit collection size and handle items with errors
- Thread-safe result access methods
- Type-safe `ExtractData` helper function for retrieving typed data

### Example Usage

```go
// Create the collector
collector := &processor.ResultCollector{
    Filter: func(item *batch.Item) bool {
        // Optional custom filtering
        return true
    },
}

// Add it to the processor chain
batch.RunBatchAndWait(ctx, b, src, processor1, processor2, collector)

// Get collected results
for _, item := range collector.Results() {
    fmt.Printf("Processed item: %v\n", item.Data)
}

// Extract typed data
strings := processor.ExtractData[string](collector)

Tests and Examples

- Comprehensive unit tests for all functionality
- Thread-safety tests for concurrent processing
- Detailed examples showing integration with other processors

This PR provides a clean, standardized way to collect results from batch processing operations.