### PR TITLE
Add Channel processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ go get github.com/MasterOfBinary/gobatch
 - **Transform**: Transforms item data with a custom function.
 - **Error**: Simulates processor errors for testing.
 - **Nil**: Passes items through unchanged for benchmarking.
+- **Channel**: Writes item data to an output channel.
 
 ### Built-in Sources
 

--- a/processor/channel.go
+++ b/processor/channel.go
@@ -1,0 +1,39 @@
+package processor
+
+import (
+    "context"
+
+    "github.com/MasterOfBinary/gobatch/batch"
+)
+
+// Channel is a Processor that sends the Data field of each item to an output
+// channel. Items with existing errors are ignored. The channel is not closed by
+// the processor.
+type Channel struct {
+    // Output is the channel that receives each item's Data value.
+    // If nil, the processor does nothing.
+    Output chan<- interface{}
+}
+
+// Process implements the Processor interface by forwarding item data to the
+// Output channel until the context is canceled.
+func (p *Channel) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+    if len(items) == 0 || p.Output == nil {
+        return items, nil
+    }
+
+    for _, item := range items {
+        if item.Error != nil {
+            continue
+        }
+
+        select {
+        case <-ctx.Done():
+            return items, ctx.Err()
+        case p.Output <- item.Data:
+        }
+    }
+
+    return items, nil
+}
+

--- a/processor/channel_test.go
+++ b/processor/channel_test.go
@@ -1,0 +1,134 @@
+package processor
+
+import (
+    "context"
+    "errors"
+    "testing"
+    "time"
+
+    "github.com/MasterOfBinary/gobatch/batch"
+)
+
+func TestChannel_Process(t *testing.T) {
+    t.Run("writes data to output channel", func(t *testing.T) {
+        out := make(chan interface{}, 3)
+        processor := &Channel{Output: out}
+
+        items := []*batch.Item{
+            {ID: 1, Data: "a"},
+            {ID: 2, Data: "b"},
+            {ID: 3, Data: "c"},
+        }
+
+        ctx := context.Background()
+        result, err := processor.Process(ctx, items)
+        if err != nil {
+            t.Errorf("unexpected error: %v", err)
+        }
+
+        if len(result) != len(items) {
+            t.Errorf("expected %d items, got %d", len(items), len(result))
+        }
+
+        close(out)
+        var collected []interface{}
+        for v := range out {
+            collected = append(collected, v)
+        }
+
+        if len(collected) != len(items) {
+            t.Errorf("expected %d values, got %d", len(items), len(collected))
+        }
+
+        for i, v := range collected {
+            if v != items[i].Data {
+                t.Errorf("value %d: expected %v, got %v", i, items[i].Data, v)
+            }
+        }
+    })
+
+    t.Run("respects context cancellation", func(t *testing.T) {
+        out := make(chan interface{})
+        processor := &Channel{Output: out}
+        ctx, cancel := context.WithCancel(context.Background())
+        cancel()
+
+        items := []*batch.Item{{ID: 1, Data: "test"}}
+        _, err := processor.Process(ctx, items)
+
+        if err != context.Canceled {
+            t.Errorf("expected context.Canceled, got %v", err)
+        }
+
+        select {
+        case <-time.After(50 * time.Millisecond):
+            // output channel should be empty
+        case v := <-out:
+            t.Errorf("expected no value sent, got %v", v)
+        }
+    })
+
+    t.Run("handles nil output channel", func(t *testing.T) {
+        processor := &Channel{Output: nil}
+        items := []*batch.Item{{ID: 1, Data: "data"}}
+        ctx := context.Background()
+
+        result, err := processor.Process(ctx, items)
+        if err != nil {
+            t.Errorf("unexpected error: %v", err)
+        }
+
+        if len(result) != 1 || result[0].Data != "data" {
+            t.Errorf("items should be unchanged")
+        }
+    })
+
+    t.Run("skips items with existing errors", func(t *testing.T) {
+        out := make(chan interface{}, 2)
+        processor := &Channel{Output: out}
+
+        items := []*batch.Item{
+            {ID: 1, Data: "a", Error: errors.New("fail")},
+            {ID: 2, Data: "b"},
+        }
+
+        ctx := context.Background()
+        _, err := processor.Process(ctx, items)
+        if err != nil {
+            t.Errorf("unexpected error: %v", err)
+        }
+        close(out)
+
+        var collected []interface{}
+        for v := range out {
+            collected = append(collected, v)
+        }
+
+        if len(collected) != 1 || collected[0] != "b" {
+            t.Errorf("expected only 'b' in output, got %v", collected)
+        }
+    })
+
+    t.Run("handles empty slice", func(t *testing.T) {
+        out := make(chan interface{}, 1)
+        processor := &Channel{Output: out}
+        ctx := context.Background()
+
+        result, err := processor.Process(ctx, []*batch.Item{})
+        if err != nil {
+            t.Errorf("unexpected error: %v", err)
+        }
+
+        if len(result) != 0 {
+            t.Errorf("expected empty result, got %d", len(result))
+        }
+
+        // there should be nothing in the channel
+        select {
+        case v := <-out:
+            t.Errorf("unexpected value %v", v)
+        default:
+        }
+    })
+}
+

--- a/processor/doc.go
+++ b/processor/doc.go
@@ -5,6 +5,7 @@
 // - Filter: For filtering items based on custom predicates
 // - Nil: For testing timing behavior without modifying items
 // - Transform: For transforming item data values
+// - Channel: For writing item data to an output channel
 //
 // Each processor implementation follows a consistent error handling pattern and
 // respects context cancellation.


### PR DESCRIPTION
## Summary
- add a new `processor.Channel` that writes item data to a channel
- document the new processor
- mention the processor in README
- include comprehensive tests for processor.Channel

## Testing
- `go vet ./...`
- `go test ./...`
