### PR TITLE
Enforce gofmt and format existing files

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,13 @@ jobs:
         # Install golangci-lint (modern replacement for gometalinter)
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
 
+    - name: Check gofmt
+      run: |
+        files=$(gofmt -l $(git ls-files '*.go'))
+        if [ -n "$files" ]; then
+          echo "The following files need gofmt:" && echo "$files" && exit 1
+        fi
+
     - name: Test with coverage
       run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 

--- a/batch/example_dynamic_config_test.go
+++ b/batch/example_dynamic_config_test.go
@@ -53,14 +53,14 @@ func Example_dynamicConfig() {
 		for i := 0; i < 100; i++ {
 			ch <- i
 
-                       switch i {
-                       case 20:
-                               fmt.Println("*** Updating batch size: min=10, max=20 ***")
-                               cfg.UpdateBatchSize(10, 20)
-                       case 50:
-                               fmt.Println("*** Updating batch size: min=20, max=30 ***")
-                               cfg.UpdateBatchSize(20, 30)
-                       }
+			switch i {
+			case 20:
+				fmt.Println("*** Updating batch size: min=10, max=20 ***")
+				cfg.UpdateBatchSize(10, 20)
+			case 50:
+				fmt.Println("*** Updating batch size: min=20, max=30 ***")
+				cfg.UpdateBatchSize(20, 30)
+			}
 
 			time.Sleep(5 * time.Millisecond)
 		}

--- a/batch/testhelpers_test.go
+++ b/batch/testhelpers_test.go
@@ -128,4 +128,3 @@ func (p *testProcessor) Process(ctx context.Context, items []*Item) ([]*Item, er
 	}
 	return items, nil
 }
-

--- a/processor/channel.go
+++ b/processor/channel.go
@@ -1,39 +1,38 @@
 package processor
 
 import (
-    "context"
+	"context"
 
-    "github.com/MasterOfBinary/gobatch/batch"
+	"github.com/MasterOfBinary/gobatch/batch"
 )
 
 // Channel is a Processor that sends the Data field of each item to an output
 // channel. Items with existing errors are ignored. The channel is not closed by
 // the processor.
 type Channel struct {
-    // Output is the channel that receives each item's Data value.
-    // If nil, the processor does nothing.
-    Output chan<- interface{}
+	// Output is the channel that receives each item's Data value.
+	// If nil, the processor does nothing.
+	Output chan<- interface{}
 }
 
 // Process implements the Processor interface by forwarding item data to the
 // Output channel until the context is canceled.
 func (p *Channel) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
-    if len(items) == 0 || p.Output == nil {
-        return items, nil
-    }
+	if len(items) == 0 || p.Output == nil {
+		return items, nil
+	}
 
-    for _, item := range items {
-        if item.Error != nil {
-            continue
-        }
+	for _, item := range items {
+		if item.Error != nil {
+			continue
+		}
 
-        select {
-        case <-ctx.Done():
-            return items, ctx.Err()
-        case p.Output <- item.Data:
-        }
-    }
+		select {
+		case <-ctx.Done():
+			return items, ctx.Err()
+		case p.Output <- item.Data:
+		}
+	}
 
-    return items, nil
+	return items, nil
 }
-

--- a/processor/channel_test.go
+++ b/processor/channel_test.go
@@ -1,134 +1,133 @@
 package processor
 
 import (
-    "context"
-    "errors"
-    "testing"
-    "time"
+	"context"
+	"errors"
+	"testing"
+	"time"
 
-    "github.com/MasterOfBinary/gobatch/batch"
+	"github.com/MasterOfBinary/gobatch/batch"
 )
 
 func TestChannel_Process(t *testing.T) {
-    t.Run("writes data to output channel", func(t *testing.T) {
-        out := make(chan interface{}, 3)
-        processor := &Channel{Output: out}
+	t.Run("writes data to output channel", func(t *testing.T) {
+		out := make(chan interface{}, 3)
+		processor := &Channel{Output: out}
 
-        items := []*batch.Item{
-            {ID: 1, Data: "a"},
-            {ID: 2, Data: "b"},
-            {ID: 3, Data: "c"},
-        }
+		items := []*batch.Item{
+			{ID: 1, Data: "a"},
+			{ID: 2, Data: "b"},
+			{ID: 3, Data: "c"},
+		}
 
-        ctx := context.Background()
-        result, err := processor.Process(ctx, items)
-        if err != nil {
-            t.Errorf("unexpected error: %v", err)
-        }
+		ctx := context.Background()
+		result, err := processor.Process(ctx, items)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 
-        if len(result) != len(items) {
-            t.Errorf("expected %d items, got %d", len(items), len(result))
-        }
+		if len(result) != len(items) {
+			t.Errorf("expected %d items, got %d", len(items), len(result))
+		}
 
-        close(out)
-        var collected []interface{}
-        for v := range out {
-            collected = append(collected, v)
-        }
+		close(out)
+		var collected []interface{}
+		for v := range out {
+			collected = append(collected, v)
+		}
 
-        if len(collected) != len(items) {
-            t.Errorf("expected %d values, got %d", len(items), len(collected))
-        }
+		if len(collected) != len(items) {
+			t.Errorf("expected %d values, got %d", len(items), len(collected))
+		}
 
-        for i, v := range collected {
-            if v != items[i].Data {
-                t.Errorf("value %d: expected %v, got %v", i, items[i].Data, v)
-            }
-        }
-    })
+		for i, v := range collected {
+			if v != items[i].Data {
+				t.Errorf("value %d: expected %v, got %v", i, items[i].Data, v)
+			}
+		}
+	})
 
-    t.Run("respects context cancellation", func(t *testing.T) {
-        out := make(chan interface{})
-        processor := &Channel{Output: out}
-        ctx, cancel := context.WithCancel(context.Background())
-        cancel()
+	t.Run("respects context cancellation", func(t *testing.T) {
+		out := make(chan interface{})
+		processor := &Channel{Output: out}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
 
-        items := []*batch.Item{{ID: 1, Data: "test"}}
-        _, err := processor.Process(ctx, items)
+		items := []*batch.Item{{ID: 1, Data: "test"}}
+		_, err := processor.Process(ctx, items)
 
-        if err != context.Canceled {
-            t.Errorf("expected context.Canceled, got %v", err)
-        }
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
 
-        select {
-        case <-time.After(50 * time.Millisecond):
-            // output channel should be empty
-        case v := <-out:
-            t.Errorf("expected no value sent, got %v", v)
-        }
-    })
+		select {
+		case <-time.After(50 * time.Millisecond):
+			// output channel should be empty
+		case v := <-out:
+			t.Errorf("expected no value sent, got %v", v)
+		}
+	})
 
-    t.Run("handles nil output channel", func(t *testing.T) {
-        processor := &Channel{Output: nil}
-        items := []*batch.Item{{ID: 1, Data: "data"}}
-        ctx := context.Background()
+	t.Run("handles nil output channel", func(t *testing.T) {
+		processor := &Channel{Output: nil}
+		items := []*batch.Item{{ID: 1, Data: "data"}}
+		ctx := context.Background()
 
-        result, err := processor.Process(ctx, items)
-        if err != nil {
-            t.Errorf("unexpected error: %v", err)
-        }
+		result, err := processor.Process(ctx, items)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 
-        if len(result) != 1 || result[0].Data != "data" {
-            t.Errorf("items should be unchanged")
-        }
-    })
+		if len(result) != 1 || result[0].Data != "data" {
+			t.Errorf("items should be unchanged")
+		}
+	})
 
-    t.Run("skips items with existing errors", func(t *testing.T) {
-        out := make(chan interface{}, 2)
-        processor := &Channel{Output: out}
+	t.Run("skips items with existing errors", func(t *testing.T) {
+		out := make(chan interface{}, 2)
+		processor := &Channel{Output: out}
 
-        items := []*batch.Item{
-            {ID: 1, Data: "a", Error: errors.New("fail")},
-            {ID: 2, Data: "b"},
-        }
+		items := []*batch.Item{
+			{ID: 1, Data: "a", Error: errors.New("fail")},
+			{ID: 2, Data: "b"},
+		}
 
-        ctx := context.Background()
-        _, err := processor.Process(ctx, items)
-        if err != nil {
-            t.Errorf("unexpected error: %v", err)
-        }
-        close(out)
+		ctx := context.Background()
+		_, err := processor.Process(ctx, items)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(out)
 
-        var collected []interface{}
-        for v := range out {
-            collected = append(collected, v)
-        }
+		var collected []interface{}
+		for v := range out {
+			collected = append(collected, v)
+		}
 
-        if len(collected) != 1 || collected[0] != "b" {
-            t.Errorf("expected only 'b' in output, got %v", collected)
-        }
-    })
+		if len(collected) != 1 || collected[0] != "b" {
+			t.Errorf("expected only 'b' in output, got %v", collected)
+		}
+	})
 
-    t.Run("handles empty slice", func(t *testing.T) {
-        out := make(chan interface{}, 1)
-        processor := &Channel{Output: out}
-        ctx := context.Background()
+	t.Run("handles empty slice", func(t *testing.T) {
+		out := make(chan interface{}, 1)
+		processor := &Channel{Output: out}
+		ctx := context.Background()
 
-        result, err := processor.Process(ctx, []*batch.Item{})
-        if err != nil {
-            t.Errorf("unexpected error: %v", err)
-        }
+		result, err := processor.Process(ctx, []*batch.Item{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 
-        if len(result) != 0 {
-            t.Errorf("expected empty result, got %d", len(result))
-        }
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got %d", len(result))
+		}
 
-        // there should be nothing in the channel
-        select {
-        case v := <-out:
-            t.Errorf("unexpected value %v", v)
-        default:
-        }
-    })
+		// there should be nothing in the channel
+		select {
+		case v := <-out:
+			t.Errorf("unexpected value %v", v)
+		default:
+		}
+	})
 }
-


### PR DESCRIPTION
## Summary
- run gofmt on the codebase to fix formatting issues
- add a GitHub Actions step that fails if any files need gofmt

## Testing
- `go vet ./...`
- `go test ./...`
