### PR TITLE
Handle negative time in fixConfig

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -376,12 +376,19 @@ func (b *Batch) doProcessors(ctx context.Context) {
 // fixConfig corrects invalid ConfigValues to ensure consistent batch behavior.
 //
 // It applies the following adjustments:
+//   - Negative MinTime or MaxTime values are clamped to 0.
 //   - If MinItems is zero, it sets it to 1 (at least one item must be processed).
 //   - If MaxTime is set and smaller than MinTime, MinTime is reduced to MaxTime.
 //   - If MaxItems is set and smaller than MinItems, MinItems is reduced to MaxItems.
 //
 // These adjustments guarantee that batching rules do not conflict at runtime.
 func fixConfig(c ConfigValues) ConfigValues {
+	if c.MinTime < 0 {
+		c.MinTime = 0
+	}
+	if c.MaxTime < 0 {
+		c.MaxTime = 0
+	}
 	if c.MinItems == 0 {
 		c.MinItems = 1
 	}

--- a/batch/config_test.go
+++ b/batch/config_test.go
@@ -117,3 +117,58 @@ func TestDynamicConfig_ConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestFixConfigClampNegativeDurations(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  ConfigValues
+		expect ConfigValues
+	}{
+		{
+			name: "negative min time",
+			input: ConfigValues{
+				MinItems: 1,
+				MinTime:  -5 * time.Second,
+			},
+			expect: ConfigValues{
+				MinItems: 1,
+				MinTime:  0,
+			},
+		},
+		{
+			name: "negative max time",
+			input: ConfigValues{
+				MinItems: 1,
+				MinTime:  2 * time.Second,
+				MaxTime:  -3 * time.Second,
+			},
+			expect: ConfigValues{
+				MinItems: 1,
+				MinTime:  2 * time.Second,
+				MaxTime:  0,
+			},
+		},
+		{
+			name: "both negative",
+			input: ConfigValues{
+				MinItems: 1,
+				MinTime:  -1 * time.Second,
+				MaxTime:  -2 * time.Second,
+			},
+			expect: ConfigValues{
+				MinItems: 1,
+				MinTime:  0,
+				MaxTime:  0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fixConfig(tt.input)
+			if got != tt.expect {
+				t.Errorf("expected %+v, got %+v", tt.expect, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- clamp negative `MinTime` and `MaxTime` to zero in `fixConfig`
- test that negative durations are clamped

## Testing
- `go vet ./...`
- `go test ./...`
