### PR TITLE
Update agent docs with full lint/test rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,10 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 
 
 ## Important Commands
-- Run tests: `go test ./...`
-- Lint code: `go vet ./...`
+- Format code with `gofmt` and ensure no unformatted files remain.
+- Run tests with race detection and coverage: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
+- Lint code with `go vet ./...`
+- Run `golangci-lint run` for additional lint checks.
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 - Format code with `gofmt` and ensure no unformatted files remain.
 - Run tests with race detection and coverage: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
 - Lint code with `go vet ./...`
-- Run `golangci-lint run` for additional lint checks.
+- Run `golangci-lint run --timeout=3m` for additional lint checks.
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 - Format code with `gofmt` and ensure no unformatted files remain.
 - Run tests with race detection and coverage: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
 - Lint code with `go vet ./...`
-- Run `golangci-lint run` for additional lint checks.
+- Run `golangci-lint run --timeout=3m` for additional lint checks.
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,10 @@ This file contains instructions and guidelines for Claude when working with this
 GoBatch is a Go library for batch data processing. It provides infrastructure for processing batches of data with configurable sources, processors, and pipelines. The library allows for flexible batch processing with configurable timing and item count parameters.
 
 ## Important Commands
-- Run tests: `go test ./...`
-- Lint code: `go vet ./...`
+- Format code with `gofmt` and ensure no unformatted files remain.
+- Run tests with race detection and coverage: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
+- Lint code with `go vet ./...`
+- Run `golangci-lint run` for additional lint checks.
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns


### PR DESCRIPTION
## Summary
- clarify guidelines in AGENTS.md for gofmt, go vet, golangci-lint, and running tests with coverage
- apply the same updates in CLAUDE.md

## Testing
- `gofmt -l $(git ls-files '*.go')`
- `go vet ./...`
- `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
- `golangci-lint run --timeout=3m`
