### PR TITLE
Add example snippets to package docs

### DIFF
--- a/batch/doc.go
+++ b/batch/doc.go
@@ -26,6 +26,15 @@
 // from the previous processor:
 //
 //	b.Go(ctx, source, processor1, processor2, processor3)
+
+// Basic usage:
+//
+//	cfg := NewConstantConfig(&ConfigValues{MinItems: 1})
+//	b := New(cfg)
+//	src := &source.Nil{}
+//	proc := &processor.Nil{}
+//	IgnoreErrors(b.Go(ctx, src, proc))
+//	<-b.Done()
 //
 // The configuration is reloaded before each batch is collected. This allows
 // dynamic Config implementations to update batch behavior during processing.

--- a/doc.go
+++ b/doc.go
@@ -2,9 +2,29 @@
 //
 // It consists of three subpackages:
 //
-// - batch: The core batching engine for building processing pipelines.
-// - processor: Several Processor implementations for common operations.
-// - source: Source implementations for ingesting data from various origins.
+//   - batch: The core batching engine for building processing pipelines.
+//   - processor: Several Processor implementations for common operations.
+//   - source: Source implementations for ingesting data from various origins.
+//
+// Basic usage ties these packages together:
+//
+//	cfg := batch.NewConstantConfig(&batch.ConfigValues{MinItems: 1})
+//	b := batch.New(cfg)
+//	ch := make(chan interface{}, 1)
+//	ch <- "hello"
+//	close(ch)
+//	src := &source.Channel{Input: ch}
+//	proc := &processor.Transform{Func: func(v interface{}) (interface{}, error) {
+//	    fmt.Println(v)
+//	    return v, nil
+//	}}
+//
+//	batch.IgnoreErrors(b.Go(context.Background(), src, proc))
+//	<-b.Done()
+//
+// Output:
+//
+// hello
 //
 // See the README.md for an overview of how these pieces fit together.
 package gobatch

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,30 @@
+package gobatch_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MasterOfBinary/gobatch/batch"
+	"github.com/MasterOfBinary/gobatch/processor"
+	"github.com/MasterOfBinary/gobatch/source"
+)
+
+func Example() {
+	cfg := batch.NewConstantConfig(&batch.ConfigValues{MinItems: 1})
+	b := batch.New(cfg)
+
+	ch := make(chan interface{}, 1)
+	ch <- "hello"
+	close(ch)
+
+	src := &source.Channel{Input: ch}
+	proc := &processor.Transform{Func: func(v interface{}) (interface{}, error) {
+		fmt.Println(v)
+		return v, nil
+	}}
+
+	batch.IgnoreErrors(b.Go(context.Background(), src, proc))
+	<-b.Done()
+	// Output:
+	// hello
+}

--- a/processor/doc.go
+++ b/processor/doc.go
@@ -9,4 +9,21 @@
 //
 // Each processor implementation follows a consistent error handling pattern and
 // respects context cancellation.
+//
+// Basic usage of the Transform processor:
+//
+//	p := &Transform{Func: func(v interface{}) (interface{}, error) {
+//	    if n, ok := v.(int); ok {
+//	        return n * 2, nil
+//	    }
+//	    return v, nil
+//	}}
+//
+//	items := []*batch.Item{{Data: 1}, {Data: 2}}
+//	res, _ := p.Process(context.Background(), items)
+//	fmt.Println(res[0].Data, res[1].Data)
+//
+// Output:
+//
+//	2 4
 package processor

--- a/processor/example_test.go
+++ b/processor/example_test.go
@@ -1,0 +1,24 @@
+package processor_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MasterOfBinary/gobatch/batch"
+	"github.com/MasterOfBinary/gobatch/processor"
+)
+
+func ExampleTransform() {
+	p := &processor.Transform{Func: func(v interface{}) (interface{}, error) {
+		if n, ok := v.(int); ok {
+			return n * 2, nil
+		}
+		return v, nil
+	}}
+
+	items := []*batch.Item{{Data: 1}, {Data: 2}}
+	res, _ := p.Process(context.Background(), items)
+	fmt.Println(res[0].Data, res[1].Data)
+	// Output:
+	// 2 4
+}

--- a/source/doc.go
+++ b/source/doc.go
@@ -7,4 +7,24 @@
 //
 // Each source implementation handles context cancellation properly and
 // ensures channels are closed appropriately.
+//
+// Basic usage of the Channel source:
+//
+//	input := make(chan interface{}, 2)
+//	input <- "a"
+//	input <- "b"
+//	close(input)
+//
+//	src := &Channel{Input: input}
+//	out, errs := src.Read(context.Background())
+//	for item := range out {
+//	    fmt.Println(item)
+//	}
+//	for range errs {
+//	}
+//
+// Output:
+//
+//	a
+//	b
 package source

--- a/source/example_test.go
+++ b/source/example_test.go
@@ -1,0 +1,26 @@
+package source_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MasterOfBinary/gobatch/source"
+)
+
+func ExampleChannel() {
+	input := make(chan interface{}, 2)
+	input <- "a"
+	input <- "b"
+	close(input)
+
+	src := &source.Channel{Input: input}
+	out, errs := src.Read(context.Background())
+	for item := range out {
+		fmt.Println(item)
+	}
+	for range errs {
+	}
+	// Output:
+	// a
+	// b
+}


### PR DESCRIPTION
## Summary
- document root gobatch usage with a simple pipeline example
- show minimal example in `batch` package docs
- demonstrate `Transform` processor in docs and example
- document `Channel` source usage with an example
- add corresponding example tests so snippets compile

## Testing
- `go vet ./...`
- `go test ./...`
