### PR TITLE
docs: Update CHANGELOG and README for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Note: This project is in early development. The API may change without warning i
 
 ## [0.4.0] - 2025-05-18
 
-This release addresses critical bugs affecting stability and timing, and aligns configuration defaults with documentation.
+This release addresses critical bugs affecting stability and timing, aligns configuration defaults with documentation, and introduces configurable buffer sizes for performance tuning.
+
+### Added
+
+- **Performance:** Added `WithBufferConfig` option and `BufferConfig` struct to allow customizing internal channel buffer sizes (Items, IDs, Errors). This allows for fine-tuning performance based on specific workload requirements.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ the master branch. If you need a stable release, wait for version 1.
 
 ### Latest Release - v0.4.0
 
-Version 0.4.0 addresses critical stability issues and clarifies configuration usage:
+Version 0.4.0 addresses critical stability issues, clarifies configuration usage, and adds performance tuning options:
 
+- **Performance:** Added `WithBufferConfig` option and `BufferConfig` struct to allow customizing internal channel buffer sizes (Items, IDs, Errors).
 - Fixed a busy loop in `doReader` when dealing with closed channels.
 - Fixed `MaxTime` timer logic to correctly handle idle periods (restarts timer if empty).
 - Renamed `ContinueOnError` to `StopOnError` in `Transform` processor to align with default behavior (BREAKING CHANGE).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the master branch. If you need a stable release, wait for version 1.
 
 Version 0.4.0 addresses critical stability issues, clarifies configuration usage, and adds performance tuning options:
 
-- **Performance:** Added `WithBufferConfig` option and `BufferConfig` struct to allow customizing internal channel buffer sizes (Items, IDs, Errors).
+- **Performance:** Added `WithBufferConfig` option and `BufferConfig` struct to allow customizing internal channel buffer sizes (Items, IDs, Errors). This allows for fine-tuning performance based on specific workload requirements.
 - Fixed a busy loop in `doReader` when dealing with closed channels.
 - Fixed `MaxTime` timer logic to correctly handle idle periods (restarts timer if empty).
 - Renamed `ContinueOnError` to `StopOnError` in `Transform` processor to align with default behavior (BREAKING CHANGE).


### PR DESCRIPTION
Updates the release documentation to include the configurable buffer sizes feature which was missed in the initial v0.4.0 notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates v0.4.0 release notes to include the new configurable buffer sizes (WithBufferConfig/BufferConfig) and clarifies stability/timing fixes.
> 
> - **Docs**:
>   - **CHANGELOG.md**: Add "Performance" entry detailing `WithBufferConfig` option and `BufferConfig` struct for tuning channel buffer sizes; update v0.4.0 summary line.
>   - **README.md**: Update Latest Release section to include configurable buffer sizes feature; keep notes on critical fixes and breaking rename.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67b5c4c74a8c1b169fdc1b97400c69a48c18361b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->