### PR TITLE
docs: Update v0.4.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Note: This project is in early development. The API may change without warning i
 
 ## [Unreleased]
 
-## [0.4.0] - 2025-05-18
+## [0.4.0] - 2025-11-21
 
 This release addresses critical bugs affecting stability and timing, aligns configuration defaults with documentation, and introduces configurable buffer sizes for performance tuning.
 


### PR DESCRIPTION
Updates the release date for version v0.4.0 in CHANGELOG.md to 2025-11-21.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates v0.4.0 release date in `CHANGELOG.md` to 2025-11-21.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 059eae6cd8da8260fe6c82865dd0bc0fbf588162. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->