### PR TITLE
Fix race condition allowing Batch reuse after completion

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -75,6 +75,8 @@ type Batch struct {
 	items        chan *Item
 	ids          chan uint64
 	done         chan struct{}
+	stopIDGen    chan struct{} // signals ID generator to stop
+	idGenDone    chan struct{} // closed when ID generator has exited
 
 	mu      sync.Mutex
 	running bool
@@ -285,6 +287,8 @@ func (b *Batch) Go(ctx context.Context, s Source, procs ...Processor) <-chan err
 	b.ids = make(chan uint64, idBuf)
 	b.errs = make(chan error, errBuf)
 	b.done = make(chan struct{})
+	b.stopIDGen = make(chan struct{})
+	b.idGenDone = make(chan struct{})
 
 	go b.doIDGenerator()
 	go b.doReader(ctx)
@@ -326,14 +330,16 @@ func (b *Batch) Done() <-chan struct{} {
 // doIDGenerator generates unique IDs for items in the pipeline.
 //
 // It runs as a background goroutine, incrementing a counter starting from zero
-// and sending each ID on the ids channel. It exits when the done channel is closed.
+// and sending each ID on the ids channel. It exits when the stopIDGen channel is closed,
+// and signals its exit by closing the idGenDone channel.
 func (b *Batch) doIDGenerator() {
+	defer close(b.idGenDone)
 	var id uint64
 	for {
 		select {
 		case b.ids <- id:
 			id++
-		case <-b.done:
+		case <-b.stopIDGen:
 			return
 		}
 	}
@@ -398,6 +404,17 @@ func (b *Batch) doReader(ctx context.Context) {
 // Batches are processed concurrently, but each batch is processed sequentially through the chain
 // of Processors. Each Processor receives the output from the previous one.
 func (b *Batch) doProcessors(ctx context.Context) {
+	// Capture channel references to avoid races with subsequent Go() calls.
+	// After this goroutine signals completion (by closing errs/done), a new
+	// Go() call may create new channels. Using local copies ensures we
+	// close the correct channels.
+	b.mu.Lock()
+	stopIDGen := b.stopIDGen
+	idGenDone := b.idGenDone
+	errs := b.errs
+	done := b.done
+	b.mu.Unlock()
+
 	var wg sync.WaitGroup
 
 	for {
@@ -421,24 +438,34 @@ func (b *Batch) doProcessors(ctx context.Context) {
 				var err error
 				items, err = proc.Process(ctx, items)
 				if err != nil {
-					b.errs <- &ProcessorError{Err: err}
+					errs <- &ProcessorError{Err: err}
 				}
 			}
 
 			for _, item := range items {
 				if item.Error != nil {
-					b.errs <- &ProcessorError{Err: item.Error}
+					errs <- &ProcessorError{Err: item.Error}
 				}
 			}
 		}(batch)
 	}
 
 	wg.Wait()
-	close(b.errs)
-	close(b.done)
+
+	// Stop the ID generator and wait for it to exit before signaling completion.
+	// This ensures all goroutines have exited before Go() can be called again.
+	close(stopIDGen)
+	<-idGenDone
+
+	// Set running to false BEFORE closing the public-facing channels.
+	// This ensures that when Done() or errs channel signals completion,
+	// Go() can be safely called again without a race condition.
 	b.mu.Lock()
 	b.running = false
 	b.mu.Unlock()
+
+	close(errs)
+	close(done)
 }
 
 // fixConfig corrects invalid ConfigValues to ensure consistent batch behavior.

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -759,3 +759,68 @@ func TestBatch_DoneNonBlocking(t *testing.T) {
 		}
 	})
 }
+
+func TestBatch_ReuseAfterCompletion(t *testing.T) {
+	t.Run("Go can be called again after Done returns", func(t *testing.T) {
+		b := New(NewConstantConfig(&ConfigValues{MinItems: 1}))
+
+		// First run
+		src1 := &testSource{Items: []interface{}{1, 2, 3}}
+		var count1 uint32
+		proc1 := &countProcessor{count: &count1}
+
+		errs1 := b.Go(context.Background(), src1, proc1)
+		<-b.Done()
+		for range errs1 {
+		}
+
+		if atomic.LoadUint32(&count1) != 3 {
+			t.Fatalf("first run: expected 3 items processed, got %d", count1)
+		}
+
+		// Second run - this should NOT panic
+		// Before the fix, this would panic because running was still true
+		src2 := &testSource{Items: []interface{}{4, 5, 6, 7}}
+		var count2 uint32
+		proc2 := &countProcessor{count: &count2}
+
+		errs2 := b.Go(context.Background(), src2, proc2)
+		<-b.Done()
+		for range errs2 {
+		}
+
+		if atomic.LoadUint32(&count2) != 4 {
+			t.Fatalf("second run: expected 4 items processed, got %d", count2)
+		}
+	})
+
+	t.Run("Go can be called again after error channel drained", func(t *testing.T) {
+		b := New(NewConstantConfig(&ConfigValues{MinItems: 1}))
+
+		// First run - drain error channel instead of waiting on Done
+		src1 := &testSource{Items: []interface{}{1, 2}}
+		var count1 uint32
+		proc1 := &countProcessor{count: &count1}
+
+		errs1 := b.Go(context.Background(), src1, proc1)
+		for range errs1 {
+		}
+
+		if atomic.LoadUint32(&count1) != 2 {
+			t.Fatalf("first run: expected 2 items processed, got %d", count1)
+		}
+
+		// Second run
+		src2 := &testSource{Items: []interface{}{3, 4, 5}}
+		var count2 uint32
+		proc2 := &countProcessor{count: &count2}
+
+		errs2 := b.Go(context.Background(), src2, proc2)
+		for range errs2 {
+		}
+
+		if atomic.LoadUint32(&count2) != 3 {
+			t.Fatalf("second run: expected 3 items processed, got %d", count2)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Fixed a race condition that prevented `Batch.Go()` from being called again after a previous run completed. The issue was that the `running` flag was not being set to `false` before closing the public-facing channels, allowing new `Go()` calls to proceed while cleanup was still in progress.

## Key Changes

- **Added dedicated ID generator lifecycle channels**: Introduced `stopIDGen` and `idGenDone` channels to properly signal and wait for the ID generator goroutine to exit, rather than relying on the shared `done` channel.

- **Fixed channel closure ordering in `doProcessors()`**: 
  - Capture channel references at the start to avoid races with subsequent `Go()` calls
  - Stop the ID generator and wait for it to exit before signaling completion
  - Set `running = false` BEFORE closing public-facing channels (`errs` and `done`)
  - This ensures that when completion is signaled, `Go()` can be safely called again

- **Updated ID generator documentation**: Clarified that it now exits when `stopIDGen` is closed and signals completion by closing `idGenDone`.

- **Added comprehensive test coverage**: New `TestBatch_ReuseAfterCompletion` test with two scenarios:
  - Calling `Go()` again after waiting on `Done()`
  - Calling `Go()` again after draining the error channel

## Implementation Details

The fix ensures proper synchronization by:
1. Using local copies of channels in `doProcessors()` to prevent races with new `Go()` calls
2. Waiting for the ID generator to fully exit before marking the batch as not running
3. Setting `running = false` under the mutex before closing channels, so any concurrent `Go()` call will see the correct state
4. This creates a clear happens-before relationship: completion is signaled only after all internal goroutines have exited and state is updated

https://claude.ai/code/session_01AL4gwE4wHYzYErgejo2dBM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core concurrency/cleanup ordering in the batch pipeline; mistakes could cause goroutine leaks, panics, or deadlocks, though the change is small and covered by new tests.
> 
> **Overview**
> Fixes a race in `Batch` teardown that could leave `running` true and/or close the wrong channels, preventing safe reuse of `Batch.Go()` after completion.
> 
> Introduces explicit ID-generator lifecycle management (`stopIDGen`/`idGenDone`), captures per-run channel references in `doProcessors()`, and changes shutdown ordering to stop/wait for the ID generator, set `running=false`, then close `errs`/`done`. Adds `TestBatch_ReuseAfterCompletion` to verify reusing a `Batch` works after waiting on `Done()` or draining the error channel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45da18bef57b3f22bb25db440bf874e0d2c68df7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->