### PR TITLE
docs: align batching docs with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The configuration is automatically adjusted to keep it consistent:
 
 - If `MinItems` > `MaxItems`, `MinItems` will be set to `MaxItems`.
 - If `MinTime` > `MaxTime`, `MinTime` will be set to `MaxTime`.
+- If `MinItems` is `0`, it will be set to `1`.
 ### Example: Constant Configuration
 
 ```go

--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ Configuration options include:
 
 The configuration is automatically adjusted to keep it consistent:
 
-- If `MinItems` > `MaxItems`, `MaxItems` will be set to `MinItems`.
-- If `MinTime` > `MaxTime`, `MaxTime` will be set to `MinTime`.
+- If `MinItems` > `MaxItems`, `MinItems` will be set to `MaxItems`.
+- If `MinTime` > `MaxTime`, `MinTime` will be set to `MaxTime`.
 ### Example: Constant Configuration
 
 ```go

--- a/batch/doc.go
+++ b/batch/doc.go
@@ -17,7 +17,7 @@
 //
 // - MinTime = 2s. After 1s the input channel is closed. The items are processed right away.
 // - MinItems = 10, MinTime = 2s. After 1s, 10 items have been read. They are not processed until 2s has passed.
-// - MaxItems = 10, MinTime = 2s. After 1s, 10 items have been read. They are not processed until 2s has passed.
+// - MaxItems = 10, MinTime = 2s. After 1s, 10 items have been read. They are processed right away.
 //
 // Timers and counters are relative to when the previous batch finished processing.
 // Each batch starts a new MinTime/MaxTime window and counts new items from zero.


### PR DESCRIPTION
## Summary
- update batch package docs to reflect that hitting `MaxItems` flushes immediately
- correct README config-normalization notes to match `fixConfig` behavior

## Validation
- go test -race -coverprofile=coverage.txt -covermode=atomic ./...
- go vet ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime behavior is modified, but incorrect docs could have impacted user expectations.
> 
> **Overview**
> Clarifies docs to match runtime behavior: hitting `MaxItems` flushes a batch immediately (even if `MinTime` hasn’t elapsed).
> 
> Updates README configuration-normalization notes to reflect `fixConfig` adjustments: clamp `MinItems` to `MaxItems` when exceeded, clamp `MinTime` to `MaxTime` when exceeded, and default `MinItems` from `0` to `1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81366ce87bf89b155a1d24bc35f8e4028b56962a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->