### PR TITLE
feat: migrate GoBatch API to generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Note: This project is in early development. The API may change without warning i
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-02-15
+
+This release introduces a hard switch to generics across the public API.
+
+### Changed
+
+- **BREAKING:** `Batch`, `Item`, `Source`, and `Processor` are now generic types (`Batch[T]`, `Item[T]`, `Source[T]`, `Processor[T]`).
+- **BREAKING:** `Source.Read` now uses typed output channels: `Read(ctx) (<-chan T, <-chan error)`.
+- **BREAKING:** `Processor.Process` now uses typed items: `Process(ctx, []*Item[T]) ([]*Item[T], error)`.
+- **BREAKING:** Built-in sources and processors now require explicit type parameters (for example, `source.Channel[int]` and `processor.Transform[string]`).
+- Updated helper APIs to generics:
+  - `RunBatchAndWait[T]`
+  - `BatchConfig[T]`
+  - `ExecuteBatches[T]`
+
+### Migration
+
+- Instantiate typed batches: `batch.New[int](config)` instead of `batch.New(config)`.
+- Instantiate typed sources/processors:
+  - `&source.Channel[int]{Input: ch}`
+  - `&processor.Transform[int]{Func: ...}`
+- `ExecuteBatches[T]` now requires all configs in a single call to share the same `T`.
+  - If you previously mixed different payload types in one `ExecuteBatches` call, use `BatchConfig[any]` or split calls by type.
+- Pipelines that change data types between processor stages must use `Batch[any]` with explicit type assertions/conversions.
+- Update custom source implementations to return `<-chan T` instead of `<-chan interface{}`.
+- Update custom processor implementations to accept and return `[]*batch.Item[T]`.
+
 ## [0.4.0] - 2025-11-21
 
 This release addresses critical bugs affecting stability and timing, aligns configuration defaults with documentation, and introduces configurable buffer sizes for performance tuning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This release introduces a hard switch to generics across the public API.
   - `&source.Channel[int]{Input: ch}`
   - `&processor.Transform[int]{Func: ...}`
 - `ExecuteBatches[T]` now requires all configs in a single call to share the same `T`.
-  - If you previously mixed different payload types in one `ExecuteBatches` call, use `BatchConfig[any]` or split calls by type.
+  - If you previously mixed different payload types in one `ExecuteBatches` call, use `BatchConfig[any]`, split calls by type, or orchestrate separate typed batches manually (for example, with `sync.WaitGroup`).
 - Pipelines that change data types between processor stages must use `Batch[any]` with explicit type assertions/conversions.
 - Update custom source implementations to return `<-chan T` instead of `<-chan interface{}`.
 - Update custom processor implementations to accept and return `[]*batch.Item[T]`.

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ and processing logic.
 **NOTE:** GoBatch is considered a version 0 release and is in an unstable state. Compatibility may be broken at any time on
 the master branch. If you need a stable release, wait for version 1.
 
-### Latest Release - v0.4.0
+### Latest Release - v0.5.0
 
-Version 0.4.0 addresses critical stability issues, clarifies configuration usage, and adds performance tuning options:
+Version 0.5.0 introduces a hard switch to generic APIs across the library:
 
-- **Performance:** Added `WithBufferConfig` option and `BufferConfig` struct to allow customizing internal channel buffer sizes (Items, IDs, Errors). This allows for fine-tuning performance based on specific workload requirements.
-- Fixed a busy loop in `doReader` when dealing with closed channels.
-- Fixed `MaxTime` timer logic to correctly handle idle periods (restarts timer if empty).
-- Renamed `ContinueOnError` to `StopOnError` in `Transform` processor to align with default behavior (BREAKING CHANGE).
+- **BREAKING:** `Batch`, `Item`, `Source`, and `Processor` are now generic (`Batch[T]`, `Item[T]`, `Source[T]`, `Processor[T]`).
+- **BREAKING:** `Source.Read` now returns typed item channels: `Read(ctx) (<-chan T, <-chan error)`.
+- **BREAKING:** `Processor.Process` now uses typed items: `Process(ctx, []*Item[T]) ([]*Item[T], error)`.
+- Built-in sources and processors now require type parameters (for example: `source.Channel[int]`, `processor.Transform[string]`).
 
 See the [CHANGELOG.md](./CHANGELOG.md) for complete details.
 
@@ -89,11 +89,11 @@ go get github.com/MasterOfBinary/gobatch
 
 ## Key Components
 
-- `Batch`: The main struct that manages batch processing.
-- `Source`: Provides data by implementing `Read(ctx) (<-chan interface{}, <-chan error)`.
-- `Processor`: Processes batches by implementing `Process(ctx, []*Item) ([]*Item, error)`.
+- `Batch[T]`: The main struct that manages batch processing for item type `T`.
+- `Source[T]`: Provides data by implementing `Read(ctx) (<-chan T, <-chan error)`.
+- `Processor[T]`: Processes batches by implementing `Process(ctx, []*Item[T]) ([]*Item[T], error)`.
 - `Config`: Provides dynamic configuration values.
-- `Item`: Represents a single data item with a unique ID and an optional error.
+- `Item[T]`: Represents a single typed data item with a unique ID and an optional error.
 
 ### Built-in Processors
 
@@ -133,7 +133,7 @@ import (
 
 func main() {
 	// Create a batch processor with simple config
-	b := batch.New(batch.NewConstantConfig(&batch.ConfigValues{
+	b := batch.New[int](batch.NewConstantConfig(&batch.ConfigValues{
 		MinItems: 2,
 		MaxItems: 5,
 		MinTime:  10 * time.Millisecond,
@@ -141,24 +141,21 @@ func main() {
 	}))
 
 	// Create an input channel
-	ch := make(chan interface{})
+	ch := make(chan int)
 
 	// Wrap it with a source.Channel
-	src := &source.Channel{Input: ch}
+	src := &source.Channel[int]{Input: ch}
 
 	// First processor: double each number
-	doubleProc := &processor.Transform{
-		Func: func(data interface{}) (interface{}, error) {
-			if v, ok := data.(int); ok {
-				return v * 2, nil
-			}
-			return data, nil
+	doubleProc := &processor.Transform[int]{
+		Func: func(data int) (int, error) {
+			return data * 2, nil
 		},
 	}
 
 	// Second processor: print each processed number
-	printProc := &processor.Transform{
-		Func: func(data interface{}) (interface{}, error) {
+	printProc := &processor.Transform[int]{
+		Func: func(data int) (int, error) {
 			fmt.Println(data)
 			return data, nil
 		},
@@ -225,7 +222,7 @@ config := batch.NewConstantConfig(&batch.ConfigValues{
     MaxTime:  500 * time.Millisecond,
 })
 
-batchProcessor := batch.New(config)
+batchProcessor := batch.New[int](config)
 ```
 
 ### Example: Dynamic Configuration
@@ -241,7 +238,7 @@ dynConfig := batch.NewDynamicConfig(&batch.ConfigValues{
     MaxTime:  500 * time.Millisecond,
 })
 
-batchProcessor := batch.New(dynConfig)
+batchProcessor := batch.New[int](dynConfig)
 
 // ... start processing ...
 
@@ -256,7 +253,7 @@ You can fine-tune the performance by customizing the internal channel buffer siz
 
 ```go
 // Configure custom buffer sizes
-batchProcessor := batch.New(config).WithBufferConfig(batch.BufferConfig{
+batchProcessor := batch.New[int](config).WithBufferConfig(batch.BufferConfig{
     ItemBufferSize:  1000, // Buffer for incoming items
     IDBufferSize:    1000, // Buffer for ID generation
     ErrorBufferSize: 500,  // Buffer for error reporting

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -36,12 +36,12 @@ type BufferConfig struct {
 // Any errors are wrapped in either a SourceError or a ProcessorError, so the caller
 // can determine where the errors came from.
 //
-// To create a new Batch, call New. Creating one using &Batch{} will also work.
+// To create a new Batch, call New. Creating one using &Batch[T]{} will also work.
 //
 //	// The following are equivalent:
-//	defaultBatch1 := &batch.Batch{}
-//	defaultBatch2 := batch.New(nil)
-//	defaultBatch3 := batch.New(batch.NewConstantConfig(&batch.ConfigValues{}))
+//	defaultBatch1 := &batch.Batch[any]{}
+//	defaultBatch2 := batch.New[any](nil)
+//	defaultBatch3 := batch.New[any](batch.NewConstantConfig(&batch.ConfigValues{}))
 //
 // If Config is nil, a default configuration is used, where items are processed
 // immediately as they are read.
@@ -67,12 +67,12 @@ type BufferConfig struct {
 // Errors returned on the error channel may be wrapped. Source errors will be
 // of type SourceError, processor errors will be of type ProcessorError, and
 // Batch errors (internal errors) will be plain.
-type Batch struct {
+type Batch[T any] struct {
 	config       Config
 	bufferConfig BufferConfig
-	src          Source
-	processors   []Processor
-	items        chan *Item
+	src          Source[T]
+	processors   []Processor[T]
+	items        chan *Item[T]
 	ids          chan uint64
 	done         chan struct{}
 
@@ -87,8 +87,8 @@ type Batch struct {
 // To avoid race conditions, the config cannot be changed after the Batch
 // is created. Instead, implement the Config interface to support changing
 // values.
-func New(config Config) *Batch {
-	return &Batch{
+func New[T any](config Config) *Batch[T] {
+	return &Batch[T]{
 		config: config,
 	}
 }
@@ -98,14 +98,14 @@ func New(config Config) *Batch {
 //
 // Example:
 //
-//	b := batch.New(config).WithBufferConfig(batch.BufferConfig{
+//	b := batch.New[any](config).WithBufferConfig(batch.BufferConfig{
 //		ItemBufferSize:  1000,
 //		IDBufferSize:    1000,
 //		ErrorBufferSize: 500,
 //	})
 //
 // Panics if called after Go() has started to prevent data races and confusion.
-func (b *Batch) WithBufferConfig(config BufferConfig) *Batch {
+func (b *Batch[T]) WithBufferConfig(config BufferConfig) *Batch[T] {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -118,19 +118,19 @@ func (b *Batch) WithBufferConfig(config BufferConfig) *Batch {
 }
 
 // Item represents a single data item flowing through the batch pipeline.
-type Item struct {
+type Item[T any] struct {
 	// ID is a unique identifier for the item. It must not be modified by processors.
 	ID uint64
 
 	// Data holds the payload being processed. It is safe for processors to modify.
-	Data interface{}
+	Data T
 
 	// Error is set by processors to indicate a failure specific to this item.
 	Error error
 }
 
 // Source reads items that are to be batch processed.
-type Source interface {
+type Source[T any] interface {
 	// Read reads items from a data source and returns two channels:
 	// one for items, and one for errors.
 	//
@@ -139,8 +139,8 @@ type Source interface {
 	//
 	// Example:
 	//
-	//	func (s *MySource) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	//		out := make(chan interface{})
+	//	func (s *MySource) Read(ctx context.Context) (<-chan int, <-chan error) {
+	//		out := make(chan int)
 	//		errs := make(chan error)
 	//
 	//		go func() {
@@ -160,13 +160,13 @@ type Source interface {
 	//
 	//		return out, errs
 	//	}
-	Read(ctx context.Context) (<-chan interface{}, <-chan error)
+	Read(ctx context.Context) (<-chan T, <-chan error)
 }
 
 // Processor processes items in batches. Implementations apply operations to each batch
 // and may modify items or set per-item errors. Processors can be chained together to
 // form multi-stage pipelines.
-type Processor interface {
+type Processor[T any] interface {
 	// Process applies operations to a batch of items.
 	// It may modify item data or set item.Error on individual items.
 	//
@@ -175,7 +175,7 @@ type Processor interface {
 	//
 	// Example:
 	//
-	//	func (p *MyProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+	//	func (p *MyProcessor) Process(ctx context.Context, items []*batch.Item[int]) ([]*batch.Item[int], error) {
 	//		for _, item := range items {
 	//			if item.Error != nil {
 	//				continue
@@ -198,7 +198,7 @@ type Processor interface {
 	//
 	//		return items, nil
 	//	}
-	Process(ctx context.Context, items []*Item) ([]*Item, error)
+	Process(ctx context.Context, items []*Item[T]) ([]*Item[T], error)
 }
 
 // Go starts batch processing asynchronously and returns an error channel.
@@ -217,7 +217,7 @@ type Processor interface {
 //
 // Example:
 //
-//	b := batch.New(config)
+//	b := batch.New[any](config)
 //	errs := b.Go(ctx, source, processor)
 //
 //	go func() {
@@ -232,7 +232,7 @@ type Processor interface {
 //   - The Source must close its channels when reading is complete.
 //   - Processors must check for context cancellation and stop early if needed.
 //   - All items that have already been read will be processed even if the context is canceled.
-func (b *Batch) Go(ctx context.Context, s Source, procs ...Processor) <-chan error {
+func (b *Batch[T]) Go(ctx context.Context, s Source[T], procs ...Processor[T]) <-chan error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -260,7 +260,7 @@ func (b *Batch) Go(ctx context.Context, s Source, procs ...Processor) <-chan err
 	b.src = s
 
 	// Filter out nil processors
-	b.processors = make([]Processor, 0, len(procs))
+	b.processors = make([]Processor[T], 0, len(procs))
 	for _, p := range procs {
 		if p != nil {
 			b.processors = append(b.processors, p)
@@ -281,7 +281,7 @@ func (b *Batch) Go(ctx context.Context, s Source, procs ...Processor) <-chan err
 		errBuf = DefaultErrorBufferSize
 	}
 
-	b.items = make(chan *Item, itemBuf)
+	b.items = make(chan *Item[T], itemBuf)
 	b.ids = make(chan uint64, idBuf)
 	b.errs = make(chan error, errBuf)
 	b.done = make(chan struct{})
@@ -300,7 +300,7 @@ func (b *Batch) Go(ctx context.Context, s Source, procs ...Processor) <-chan err
 //
 // Example:
 //
-//	b := batch.New(config)
+//	b := batch.New[any](config)
 //	batch.IgnoreErrors(b.Go(ctx, source, processor))
 //
 //	<-b.Done()
@@ -316,7 +316,7 @@ func (b *Batch) Go(ctx context.Context, s Source, procs ...Processor) <-chan err
 //	case <-time.After(10 * time.Second):
 //		fmt.Println("Timed out waiting for processing to finish")
 //	}
-func (b *Batch) Done() <-chan struct{} {
+func (b *Batch[T]) Done() <-chan struct{} {
 	if b.done == nil {
 		return closedDone
 	}
@@ -327,7 +327,7 @@ func (b *Batch) Done() <-chan struct{} {
 //
 // It runs as a background goroutine, incrementing a counter starting from zero
 // and sending each ID on the ids channel. It exits when the done channel is closed.
-func (b *Batch) doIDGenerator() {
+func (b *Batch[T]) doIDGenerator() {
 	var id uint64
 	for {
 		select {
@@ -347,7 +347,7 @@ func (b *Batch) doIDGenerator() {
 //
 // When both the data and error channels are closed, it closes the items channel
 // to signal that no more data will be produced.
-func (b *Batch) doReader(ctx context.Context) {
+func (b *Batch[T]) doReader(ctx context.Context) {
 	// Get channels from source
 	out, errs := b.src.Read(ctx)
 
@@ -368,7 +368,7 @@ func (b *Batch) doReader(ctx context.Context) {
 				continue
 			}
 			id := <-b.ids
-			b.items <- &Item{
+			b.items <- &Item[T]{
 				ID:   id,
 				Data: data,
 			}
@@ -397,7 +397,7 @@ func (b *Batch) doReader(ctx context.Context) {
 //
 // Batches are processed concurrently, but each batch is processed sequentially through the chain
 // of Processors. Each Processor receives the output from the previous one.
-func (b *Batch) doProcessors(ctx context.Context) {
+func (b *Batch[T]) doProcessors(ctx context.Context) {
 	var wg sync.WaitGroup
 
 	for {
@@ -410,7 +410,7 @@ func (b *Batch) doProcessors(ctx context.Context) {
 		}
 
 		wg.Add(1)
-		go func(items []*Item) {
+		go func(items []*Item[T]) {
 			defer wg.Done()
 			for _, proc := range b.processors {
 				// Skip nil processors (although they should have been filtered out in Go)
@@ -476,10 +476,10 @@ func fixConfig(c ConfigValues) ConfigValues {
 //   - MinItems: If reached, waits until MinTime is also satisfied.
 //
 // The method returns the collected batch of items.
-func (b *Batch) waitForItems(_ context.Context, config ConfigValues) []*Item {
+func (b *Batch[T]) waitForItems(_ context.Context, config ConfigValues) []*Item[T] {
 	var (
 		reachedMinTime bool
-		batch          = make([]*Item, 0, config.MinItems)
+		batch          = make([]*Item[T], 0, config.MinItems)
 		minTimer       <-chan time.Time
 		maxTimer       <-chan time.Time
 	)

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -15,10 +15,10 @@ import (
 func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 	t.Run("processor chaining with individual errors", func(t *testing.T) {
 		var count uint32
-		batch := New(NewConstantConfig(&ConfigValues{
+		batch := New[any](NewConstantConfig(&ConfigValues{
 			MinItems: 5,
 		}))
-		src := &testSource{Items: []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9}}
+		src := &testSource{Items: []any{1, 2, 3, 4, 5, 6, 7, 8, 9}}
 		errProc := &errorPerItemProcessor{FailEvery: 3}
 		countProc := &countProcessor{count: &count}
 
@@ -48,8 +48,8 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 
 	t.Run("source error forwarding", func(t *testing.T) {
 		srcErr := errors.New("source failed")
-		batch := New(NewConstantConfig(&ConfigValues{}))
-		src := &testSource{Items: []interface{}{1, 2}, WithErr: srcErr}
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
+		src := &testSource{Items: []any{1, 2}, WithErr: srcErr}
 		countProc := &countProcessor{count: new(uint32)}
 
 		errs := batch.Go(context.Background(), src, countProc)
@@ -71,8 +71,8 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 	// Test processor error handling and unwrapping
 	t.Run("processor error handling", func(t *testing.T) {
 		procErr := errors.New("processor failed")
-		batch := New(NewConstantConfig(&ConfigValues{}))
-		src := &testSource{Items: []interface{}{1, 2, 3}}
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
+		src := &testSource{Items: []any{1, 2, 3}}
 		proc := &countProcessor{count: new(uint32), processorErr: procErr}
 
 		errs := batch.Go(context.Background(), src, proc)
@@ -102,13 +102,13 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 	// Test context cancellation behavior
 	t.Run("context cancellation", func(t *testing.T) {
 		var count uint32
-		batch := New(NewConstantConfig(&ConfigValues{
+		batch := New[any](NewConstantConfig(&ConfigValues{
 			MinItems: 100,         // Force waiting for items
 			MaxTime:  time.Minute, // Prevent triggering MaxTime
 		}))
 
 		// Create a dataset with delay to ensure cancellation happens during processing
-		items := make([]interface{}, 200)
+		items := make([]any, 200)
 		for i := range items {
 			items[i] = i
 		}
@@ -267,12 +267,12 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 				t.Parallel()
 
 				var count uint32
-				items := make([]interface{}, tt.size)
+				items := make([]any, tt.size)
 				for i := 0; i < tt.size; i++ {
 					items[i] = rand.Int()
 				}
 
-				batch := New(NewConstantConfig(tt.config))
+				batch := New[any](NewConstantConfig(tt.config))
 				src := &testSource{Items: items, Delay: tt.duration}
 
 				// Collect batch sizes
@@ -280,7 +280,7 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 				var batchMu sync.Mutex
 
 				proc := &testProcessor{
-					processFn: func(ctx context.Context, items []*Item) ([]*Item, error) {
+					processFn: func(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
 						batchMu.Lock()
 						batchSizes = append(batchSizes, len(items))
 						batchMu.Unlock()
@@ -342,7 +342,7 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 		// even if MinItems is not met
 		t.Run("process all items when source exhausted", func(t *testing.T) {
 			// Create a source with items that won't divide evenly by MinItems
-			items := []interface{}{"item1", "item2", "item3", "item4", "item5"}
+			items := []any{"item1", "item2", "item3", "item4", "item5"}
 
 			// Use a test source with delay to make batching more predictable
 			s := &testSource{
@@ -351,13 +351,13 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 			}
 
 			// Track processed items and batch sizes
-			var processedItems []interface{}
+			var processedItems []any
 			var batchSizes []int
 			var mu sync.Mutex
 
 			// Create a processor that records processed items and batch sizes
 			p := &testProcessor{
-				processFn: func(ctx context.Context, items []*Item) ([]*Item, error) {
+				processFn: func(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
 					mu.Lock()
 					defer mu.Unlock()
 
@@ -365,7 +365,7 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 					batchSizes = append(batchSizes, len(items))
 
 					// Record processed items
-					batch := make([]interface{}, 0, len(items))
+					batch := make([]any, 0, len(items))
 					for _, item := range items {
 						processedItems = append(processedItems, item.Data)
 						batch = append(batch, item.Data)
@@ -384,7 +384,7 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 				MaxItems: 2,
 			})
 
-			b := New(config)
+			b := New[any](config)
 			ctx := context.Background()
 
 			// Start processing and wait for completion
@@ -432,10 +432,10 @@ func TestBatch_ProcessorChainingAndErrorTracking(t *testing.T) {
 
 func TestBatch_ComplexProcessingPipeline(t *testing.T) {
 	t.Run("transform and filter pipeline", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{MinItems: 2}))
+		batch := New[any](NewConstantConfig(&ConfigValues{MinItems: 2}))
 
 		// Create test data: 1-10
-		items := make([]interface{}, 10)
+		items := make([]any, 10)
 		for i := 0; i < 10; i++ {
 			items[i] = i + 1
 		}
@@ -444,14 +444,14 @@ func TestBatch_ComplexProcessingPipeline(t *testing.T) {
 
 		// Double each number
 		transformer := &transformProcessor{
-			transformFn: func(val interface{}) interface{} {
+			transformFn: func(val any) any {
 				return val.(int) * 2
 			},
 		}
 
 		// Keep only even numbers (which will be all of them after doubling)
 		filter := &filterProcessor{
-			filterFn: func(val interface{}) bool {
+			filterFn: func(val any) bool {
 				return val.(int)%2 == 0
 			},
 		}
@@ -497,12 +497,12 @@ func TestBatch_ConcurrentProcessing(t *testing.T) {
 				defer wg.Done()
 
 				// Create items
-				items := make([]interface{}, itemsPerBatch)
+				items := make([]any, itemsPerBatch)
 				for j := 0; j < itemsPerBatch; j++ {
 					items[j] = j
 				}
 
-				batch := New(NewConstantConfig(&ConfigValues{MaxItems: 10}))
+				batch := New[any](NewConstantConfig(&ConfigValues{MaxItems: 10}))
 				src := &testSource{Items: items}
 				proc := &countProcessor{count: counters[i]}
 
@@ -529,12 +529,12 @@ func TestBatch_RobustnessAndEdgeCases(t *testing.T) {
 		// Test with a large number of items to ensure memory efficiency
 		const largeItemCount = 1000 // Reduced from 100000 to make test run faster
 
-		batch := New(NewConstantConfig(&ConfigValues{
+		batch := New[any](NewConstantConfig(&ConfigValues{
 			MaxItems: 1000, // Process in chunks of 1000
 		}))
 
 		// Create large dataset
-		items := make([]interface{}, largeItemCount)
+		items := make([]any, largeItemCount)
 		for i := 0; i < largeItemCount; i++ {
 			items[i] = i
 		}
@@ -562,8 +562,8 @@ func TestBatch_RobustnessAndEdgeCases(t *testing.T) {
 	// Instead, let's add tests with valid processors with various config options
 
 	t.Run("empty items slice", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
-		src := &testSource{Items: []interface{}{}} // Empty but not nil
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
+		src := &testSource{Items: []any{}} // Empty but not nil
 		var count uint32
 		proc := &countProcessor{count: &count}
 
@@ -583,14 +583,14 @@ func TestBatch_RobustnessAndEdgeCases(t *testing.T) {
 
 	t.Run("zero configuration values", func(t *testing.T) {
 		// Test with all zeros in config values
-		batch := New(NewConstantConfig(&ConfigValues{
+		batch := New[any](NewConstantConfig(&ConfigValues{
 			MinItems: 0,
 			MaxItems: 0,
 			MinTime:  0,
 			MaxTime:  0,
 		}))
 
-		items := []interface{}{1, 2, 3, 4, 5}
+		items := []any{1, 2, 3, 4, 5}
 		src := &testSource{Items: items}
 		var count uint32
 		proc := &countProcessor{count: &count}
@@ -612,13 +612,13 @@ func TestBatch_RobustnessAndEdgeCases(t *testing.T) {
 	t.Run("very small min/max time values", func(t *testing.T) {
 		// Very small time values can be zero in practice due to timer resolution
 		// So it's better to test without time constraints
-		batch := New(NewConstantConfig(&ConfigValues{
+		batch := New[any](NewConstantConfig(&ConfigValues{
 			// No time constraints, just use item count
 			MinItems: 1,
 			MaxItems: 10,
 		}))
 
-		items := []interface{}{1, 2, 3, 4, 5}
+		items := []any{1, 2, 3, 4, 5}
 		src := &testSource{Items: items}
 		var count uint32
 		proc := &countProcessor{count: &count}
@@ -640,10 +640,10 @@ func TestBatch_RobustnessAndEdgeCases(t *testing.T) {
 
 func TestBatch_NoProcessors(t *testing.T) {
 	t.Run("no processors provided", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
 
 		// Create source with data
-		items := []interface{}{1, 2, 3, 4, 5}
+		items := []any{1, 2, 3, 4, 5}
 		src := &testSource{Items: items}
 
 		// Call Go with source but no processors
@@ -665,14 +665,14 @@ func TestBatch_NoProcessors(t *testing.T) {
 	})
 
 	t.Run("empty processor slice", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
 
 		// Create source with data
-		items := []interface{}{1, 2, 3, 4, 5}
+		items := []any{1, 2, 3, 4, 5}
 		src := &testSource{Items: items}
 
 		// Create an empty slice of processors
-		emptyProcessors := make([]Processor, 0)
+		emptyProcessors := make([]Processor[any], 0)
 
 		// Call Go with source and empty processor slice
 		errs := batch.Go(context.Background(), src, emptyProcessors...)
@@ -695,9 +695,9 @@ func TestBatch_NoProcessors(t *testing.T) {
 
 func TestBatch_NoTimersWithMinItems(t *testing.T) {
 	t.Run("min items without timers", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{MinItems: 2}))
+		batch := New[any](NewConstantConfig(&ConfigValues{MinItems: 2}))
 
-		items := []interface{}{"a", "b", "c", "d", "e"}
+		items := []any{"a", "b", "c", "d", "e"}
 		src := &testSource{Items: items, Delay: 10 * time.Millisecond}
 
 		var (
@@ -706,7 +706,7 @@ func TestBatch_NoTimersWithMinItems(t *testing.T) {
 		)
 
 		proc := &testProcessor{
-			processFn: func(ctx context.Context, it []*Item) ([]*Item, error) {
+			processFn: func(ctx context.Context, it []*Item[any]) ([]*Item[any], error) {
 				mu.Lock()
 				defer mu.Unlock()
 
@@ -734,7 +734,7 @@ func TestBatch_NoTimersWithMinItems(t *testing.T) {
 
 func TestBatch_DoneNonBlocking(t *testing.T) {
 	t.Run("before Go", func(t *testing.T) {
-		b := New(NewConstantConfig(nil))
+		b := New[any](NewConstantConfig(nil))
 		select {
 		case <-b.Done():
 		// channel should already be closed
@@ -744,8 +744,8 @@ func TestBatch_DoneNonBlocking(t *testing.T) {
 	})
 
 	t.Run("after Go", func(t *testing.T) {
-		b := New(NewConstantConfig(nil))
-		src := &testSource{Items: []interface{}{}}
+		b := New[any](NewConstantConfig(nil))
+		src := &testSource{Items: []any{}}
 		errs := b.Go(context.Background(), src)
 		<-b.Done()
 		for range errs {

--- a/batch/buffer_config_test.go
+++ b/batch/buffer_config_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 // testSourceFunc test helper - simple source implementation
-type testSourceFunc func(ctx context.Context) (<-chan interface{}, <-chan error)
+type testSourceFunc func(ctx context.Context) (<-chan any, <-chan error)
 
-func (f testSourceFunc) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
+func (f testSourceFunc) Read(ctx context.Context) (<-chan any, <-chan error) {
 	return f(ctx)
 }
 
@@ -21,7 +21,7 @@ func TestBatch_WithBufferConfig(t *testing.T) {
 			ErrorBufferSize: 200,
 		}
 
-		b := New(nil).WithBufferConfig(customConfig)
+		b := New[any](nil).WithBufferConfig(customConfig)
 
 		// Verify the config was set
 		if b.bufferConfig.ItemBufferSize != 500 {
@@ -37,11 +37,11 @@ func TestBatch_WithBufferConfig(t *testing.T) {
 
 	t.Run("zero values use defaults", func(t *testing.T) {
 		// Create batch with zero buffer config
-		b := New(nil)
+		b := New[any](nil)
 
 		// Create a simple source
-		src := testSourceFunc(func(ctx context.Context) (<-chan interface{}, <-chan error) {
-			out := make(chan interface{})
+		src := testSourceFunc(func(ctx context.Context) (<-chan any, <-chan error) {
+			out := make(chan any)
 			errs := make(chan error)
 			go func() {
 				defer close(out)
@@ -66,11 +66,11 @@ func TestBatch_WithBufferConfig(t *testing.T) {
 			ErrorBufferSize: -1,
 		}
 
-		b := New(nil).WithBufferConfig(customConfig)
+		b := New[any](nil).WithBufferConfig(customConfig)
 
 		// Create a simple source
-		src := testSourceFunc(func(ctx context.Context) (<-chan interface{}, <-chan error) {
-			out := make(chan interface{})
+		src := testSourceFunc(func(ctx context.Context) (<-chan any, <-chan error) {
+			out := make(chan any)
 			errs := make(chan error)
 			go func() {
 				defer close(out)
@@ -89,11 +89,11 @@ func TestBatch_WithBufferConfig(t *testing.T) {
 	})
 
 	t.Run("panic if called after Go", func(t *testing.T) {
-		b := New(nil)
+		b := New[any](nil)
 
 		// Create a simple source
-		src := testSourceFunc(func(ctx context.Context) (<-chan interface{}, <-chan error) {
-			out := make(chan interface{})
+		src := testSourceFunc(func(ctx context.Context) (<-chan any, <-chan error) {
+			out := make(chan any)
 			errs := make(chan error)
 			go func() {
 				defer close(out)
@@ -127,7 +127,7 @@ func TestBatch_WithBufferConfig(t *testing.T) {
 	})
 
 	t.Run("thread safe with Go", func(t *testing.T) {
-		b := New(nil)
+		b := New[any](nil)
 
 		// Try to call WithBufferConfig and Go concurrently
 		// One should succeed, one should panic
@@ -147,8 +147,8 @@ func TestBatch_WithBufferConfig(t *testing.T) {
 			defer func() {
 				done <- true
 			}()
-			src := testSourceFunc(func(ctx context.Context) (<-chan interface{}, <-chan error) {
-				out := make(chan interface{})
+			src := testSourceFunc(func(ctx context.Context) (<-chan any, <-chan error) {
+				out := make(chan any)
 				errs := make(chan error)
 				close(out)
 				close(errs)

--- a/batch/doc.go
+++ b/batch/doc.go
@@ -30,9 +30,9 @@
 // Basic usage:
 //
 //	cfg := NewConstantConfig(&ConfigValues{MinItems: 1})
-//	b := New(cfg)
-//	src := &source.Nil{}
-//	proc := &processor.Nil{}
+//	b := New[int](cfg)
+//	src := &source.Nil[int]{}
+//	proc := &processor.Nil[int]{}
 //	IgnoreErrors(b.Go(ctx, src, proc))
 //	<-b.Done()
 //

--- a/batch/dynamic_config_test.go
+++ b/batch/dynamic_config_test.go
@@ -19,11 +19,11 @@ func TestBatch_DynamicConfiguration(t *testing.T) {
 			MaxTime:  0,
 		})
 
-		batch := New(dynamicCfg)
+		batch := New[any](dynamicCfg)
 
 		// Create items
 		const totalItems = 100
-		items := make([]interface{}, totalItems)
+		items := make([]any, totalItems)
 		for i := 0; i < totalItems; i++ {
 			items[i] = i
 		}
@@ -36,7 +36,7 @@ func TestBatch_DynamicConfiguration(t *testing.T) {
 
 		// Use a new processor type that's safe for this test
 		proc := &testProcessor{
-			processFn: func(ctx context.Context, items []*Item) ([]*Item, error) {
+			processFn: func(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
 				// Add a delay to ensure the processing happens over time
 				time.Sleep(10 * time.Millisecond)
 

--- a/batch/error_handling_test.go
+++ b/batch/error_handling_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestBatch_ErrorHandling(t *testing.T) {
 	t.Run("processor with error", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
-		src := &testSource{Items: []interface{}{1, 2, 3, 4, 5}}
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
+		src := &testSource{Items: []any{1, 2, 3, 4, 5}}
 
 		procErr := errors.New("processor error")
 		proc := &countProcessor{
@@ -39,11 +39,11 @@ func TestBatch_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("source with error", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
 
 		srcErr := errors.New("source error")
 		src := &testSource{
-			Items:   []interface{}{1, 2, 3},
+			Items:   []any{1, 2, 3},
 			WithErr: srcErr,
 		}
 
@@ -67,7 +67,7 @@ func TestBatch_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("nil source handling", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
 
 		// Pass nil source
 		errs := batch.Go(context.Background(), nil)
@@ -94,8 +94,8 @@ func TestBatch_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("nil processor filtering", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
-		src := &testSource{Items: []interface{}{1, 2, 3}}
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
+		src := &testSource{Items: []any{1, 2, 3}}
 
 		// Include a nil processor among valid ones
 		var count uint32
@@ -126,7 +126,7 @@ func TestBatch_ErrorHandling(t *testing.T) {
 
 func TestBatch_NilChannelHandling(t *testing.T) {
 	t.Run("source returning nil output channel", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
 
 		// Create a source that returns a nil output channel
 		nilChannelSource := &nilOutputChannelSource{}
@@ -155,7 +155,7 @@ func TestBatch_NilChannelHandling(t *testing.T) {
 	})
 
 	t.Run("source returning nil error channel", func(t *testing.T) {
-		batch := New(NewConstantConfig(&ConfigValues{}))
+		batch := New[any](NewConstantConfig(&ConfigValues{}))
 
 		// Create a source that returns a nil error channel
 		nilChannelSource := &nilErrorChannelSource{}
@@ -187,7 +187,7 @@ func TestBatch_NilChannelHandling(t *testing.T) {
 // Source that returns a nil output channel and a valid error channel
 type nilOutputChannelSource struct{}
 
-func (s *nilOutputChannelSource) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
+func (s *nilOutputChannelSource) Read(ctx context.Context) (<-chan any, <-chan error) {
 	errs := make(chan error)
 	close(errs)
 	return nil, errs
@@ -196,8 +196,8 @@ func (s *nilOutputChannelSource) Read(ctx context.Context) (<-chan interface{}, 
 // Source that returns a valid output channel and a nil error channel
 type nilErrorChannelSource struct{}
 
-func (s *nilErrorChannelSource) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	out := make(chan interface{})
+func (s *nilErrorChannelSource) Read(ctx context.Context) (<-chan any, <-chan error) {
+	out := make(chan any)
 	close(out)
 	return out, nil
 }

--- a/batch/example_custom_config_test.go
+++ b/batch/example_custom_config_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 type sliceSource struct {
-	items []interface{}
+	items []any
 	delay time.Duration
 }
 
-func (s *sliceSource) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	out := make(chan interface{}, 100)
+func (s *sliceSource) Read(ctx context.Context) (<-chan any, <-chan error) {
+	out := make(chan any, 100)
 	errs := make(chan error)
 
 	go func() {
@@ -98,7 +98,7 @@ func (c *loadBasedConfig) UpdateLoad(load int) {
 
 type batchInfoProcessor struct{}
 
-func (p *batchInfoProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *batchInfoProcessor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	fmt.Printf("Batch of %d items\n", len(items))
 	return items, nil
 }
@@ -115,10 +115,10 @@ func Example_customConfig() {
 	fmt.Println("Initial config:")
 	printConfig(cfg.Get())
 
-	b := batch.New(cfg)
+	b := batch.New[any](cfg)
 	p := &batchInfoProcessor{}
 
-	nums := make([]interface{}, 200)
+	nums := make([]any, 200)
 	for i := range nums {
 		nums[i] = i
 	}

--- a/batch/example_dynamic_config_test.go
+++ b/batch/example_dynamic_config_test.go
@@ -17,7 +17,7 @@ type batchSizeMonitor struct {
 	items   int
 }
 
-func (p *batchSizeMonitor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *batchSizeMonitor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	p.mu.Lock()
 	p.batches++
 	p.items += len(items)
@@ -35,11 +35,11 @@ func Example_dynamicConfig() {
 		MaxItems: 10,
 	})
 
-	b := batch.New(cfg)
+	b := batch.New[any](cfg)
 	monitor := &batchSizeMonitor{name: "Dynamic"}
 
-	ch := make(chan interface{})
-	src := &source.Channel{Input: ch}
+	ch := make(chan any)
+	src := &source.Channel[any]{Input: ch}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/batch/example_error_handling_test.go
+++ b/batch/example_error_handling_test.go
@@ -16,8 +16,8 @@ type errorSource struct {
 	errorRate int
 }
 
-func (s *errorSource) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	out := make(chan interface{})
+func (s *errorSource) Read(ctx context.Context) (<-chan any, <-chan error) {
+	out := make(chan any)
 	errs := make(chan error)
 
 	go func() {
@@ -48,7 +48,7 @@ type validationProcessor struct {
 	maxValue int
 }
 
-func (p *validationProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *validationProcessor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	for _, item := range items {
 		if item.Error != nil {
 			continue
@@ -75,7 +75,7 @@ type errorProneProcessor struct {
 	batchCount  int32
 }
 
-func (p *errorProneProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *errorProneProcessor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	batchNum := atomic.AddInt32(&p.batchCount, 1)
 
 	if int(batchNum) == p.failOnBatch {
@@ -102,7 +102,7 @@ func (p *errorProneProcessor) Process(ctx context.Context, items []*batch.Item) 
 
 type errorLogger struct{}
 
-func (p *errorLogger) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *errorLogger) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	fmt.Println("Batch:")
 	errorCount := 0
 
@@ -136,14 +136,14 @@ func Example_errorHandling() {
 		MinItems: 3,
 		MaxItems: 5,
 	})
-	b := batch.New(config)
+	b := batch.New[any](config)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	fmt.Println("=== Error Handling Example ===")
 
-	errs := batch.RunBatchAndWait(ctx, b, src, validator, transformer, logger)
+	errs := batch.RunBatchAndWait[any](ctx, b, src, validator, transformer, logger)
 
 	fmt.Println("\nSummary:")
 	if len(errs) == 0 {

--- a/batch/example_processor_chain_test.go
+++ b/batch/example_processor_chain_test.go
@@ -14,8 +14,8 @@ type textSource struct {
 	texts []string
 }
 
-func (s *textSource) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	out := make(chan interface{})
+func (s *textSource) Read(ctx context.Context) (<-chan any, <-chan error) {
+	out := make(chan any)
 	errs := make(chan error)
 
 	go func() {
@@ -39,7 +39,7 @@ type validateProcessor struct {
 	maxLength int
 }
 
-func (p *validateProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *validateProcessor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	fmt.Println("Validation:")
 	for i, item := range items {
 		if item.Error != nil {
@@ -66,7 +66,7 @@ func (p *validateProcessor) Process(ctx context.Context, items []*batch.Item) ([
 
 type formatProcessor struct{}
 
-func (p *formatProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *formatProcessor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	fmt.Println("Format:")
 	for i, item := range items {
 		if item.Error != nil {
@@ -84,7 +84,7 @@ type enrichProcessor struct {
 	metadata map[string]string
 }
 
-func (p *enrichProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *enrichProcessor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	fmt.Println("Enrich:")
 	for i, item := range items {
 		if item.Error != nil {
@@ -111,7 +111,7 @@ func (p *enrichProcessor) Process(ctx context.Context, items []*batch.Item) ([]*
 
 type displayProcessor struct{}
 
-func (p *displayProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *displayProcessor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
 	fmt.Println("Results:")
 	for i, item := range items {
 		if item.Error != nil {
@@ -146,14 +146,14 @@ func Example_processorChain() {
 		MinItems: 4,
 		MaxItems: 3,
 	})
-	b := batch.New(config)
+	b := batch.New[any](config)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	fmt.Println("=== Processor Chain Example ===")
 
-	errs := batch.RunBatchAndWait(ctx, b, src,
+	errs := batch.RunBatchAndWait[any](ctx, b, src,
 		&validateProcessor{minLength: 3, maxLength: 15},
 		&formatProcessor{},
 		&enrichProcessor{metadata: meta},

--- a/batch/example_simple_processor_test.go
+++ b/batch/example_simple_processor_test.go
@@ -12,8 +12,8 @@ import (
 
 type simpleProcessor struct{}
 
-func (p *simpleProcessor) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
-	var values []interface{}
+func (p *simpleProcessor) Process(ctx context.Context, items []*batch.Item[any]) ([]*batch.Item[any], error) {
+	var values []any
 
 	for _, item := range items {
 		if val, ok := item.Data.(int); ok && val == 5 {
@@ -28,17 +28,17 @@ func (p *simpleProcessor) Process(ctx context.Context, items []*batch.Item) ([]*
 }
 
 func Example_simpleProcessor() {
-	ch := make(chan interface{})
+	ch := make(chan any)
 
 	go func() {
-		for _, v := range []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} {
+		for _, v := range []any{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} {
 			ch <- v
 			time.Sleep(10 * time.Millisecond)
 		}
 		close(ch)
 	}()
 
-	src := &source.Channel{Input: ch}
+	src := &source.Channel[any]{Input: ch}
 
 	config := batch.NewConstantConfig(&batch.ConfigValues{
 		MinItems: 3,
@@ -46,12 +46,12 @@ func Example_simpleProcessor() {
 	})
 
 	p := &simpleProcessor{}
-	b := batch.New(config)
+	b := batch.New[any](config)
 
 	ctx := context.Background()
 	fmt.Println("Starting...")
 
-	errs := batch.RunBatchAndWait(ctx, b, src, p)
+	errs := batch.RunBatchAndWait[any](ctx, b, src, p)
 
 	if len(errs) > 0 {
 		fmt.Printf("Errors: %d\n", len(errs))

--- a/batch/example_test.go
+++ b/batch/example_test.go
@@ -12,7 +12,7 @@ import (
 
 func Example() {
 	// Create a batch processor with simple config
-	b := batch.New(batch.NewConstantConfig(&batch.ConfigValues{
+	b := batch.New[int](batch.NewConstantConfig(&batch.ConfigValues{
 		MinItems: 2,
 		MaxItems: 5,
 		MinTime:  10 * time.Millisecond,
@@ -20,24 +20,21 @@ func Example() {
 	}))
 
 	// Create an input channel
-	ch := make(chan interface{})
+	ch := make(chan int)
 
 	// Wrap it with source.Channel
-	src := &source.Channel{Input: ch}
+	src := &source.Channel[int]{Input: ch}
 
 	// First processor: double the value
-	doubleProc := &processor.Transform{
-		Func: func(data interface{}) (interface{}, error) {
-			if v, ok := data.(int); ok {
-				return v * 2, nil
-			}
-			return data, nil
+	doubleProc := &processor.Transform[int]{
+		Func: func(data int) (int, error) {
+			return data * 2, nil
 		},
 	}
 
 	// Second processor: print the result
-	printProc := &processor.Transform{
-		Func: func(data interface{}) (interface{}, error) {
+	printProc := &processor.Transform[int]{
+		Func: func(data int) (int, error) {
 			fmt.Println(data)
 			return data, nil
 		},

--- a/batch/helpers.go
+++ b/batch/helpers.go
@@ -59,7 +59,7 @@ func CollectErrors(errs <-chan error) []error {
 //	if len(errs) > 0 {
 //		// Handle errors
 //	}
-func RunBatchAndWait(ctx context.Context, b *Batch, s Source, procs ...Processor) []error {
+func RunBatchAndWait[T any](ctx context.Context, b *Batch[T], s Source[T], procs ...Processor[T]) []error {
 	// Start the batch processing
 	errs := b.Go(ctx, s, procs...)
 
@@ -81,10 +81,10 @@ func RunBatchAndWait(ctx context.Context, b *Batch, s Source, procs ...Processor
 // It combines a Batch instance, a Source to read from, and a list of Processors
 // to apply to the data from the source. This is used primarily with the
 // ExecuteBatches function to run multiple batch operations concurrently.
-type BatchConfig struct {
-	B *Batch      // The Batch instance to use
-	S Source      // The Source to read items from
-	P []Processor // The processors to apply to the items
+type BatchConfig[T any] struct {
+	B *Batch[T]      // The Batch instance to use
+	S Source[T]      // The Source to read items from
+	P []Processor[T] // The processors to apply to the items
 }
 
 // ExecuteBatches runs multiple batches concurrently and waits for all to complete.
@@ -94,10 +94,10 @@ type BatchConfig struct {
 // Example usage:
 //
 //	errs := batch.ExecuteBatches(ctx,
-//		&batch.BatchConfig{B: batch1, S: source1, P: []Processor{proc1}},
-//		&batch.BatchConfig{B: batch2, S: source2, P: []Processor{proc2}},
+//		&batch.BatchConfig[int]{B: batch1, S: source1, P: []batch.Processor[int]{proc1}},
+//		&batch.BatchConfig[int]{B: batch2, S: source2, P: []batch.Processor[int]{proc2}},
 //	)
-func ExecuteBatches(ctx context.Context, configs ...*BatchConfig) []error {
+func ExecuteBatches[T any](ctx context.Context, configs ...*BatchConfig[T]) []error {
 	var (
 		wg      sync.WaitGroup
 		mu      sync.Mutex
@@ -107,7 +107,7 @@ func ExecuteBatches(ctx context.Context, configs ...*BatchConfig) []error {
 	wg.Add(len(configs))
 
 	for _, config := range configs {
-		go func(cfg *BatchConfig) {
+		go func(cfg *BatchConfig[T]) {
 			defer wg.Done()
 
 			if cfg == nil || cfg.B == nil || cfg.S == nil {

--- a/batch/helpers_test.go
+++ b/batch/helpers_test.go
@@ -75,9 +75,9 @@ func TestCollectErrors(t *testing.T) {
 
 func TestRunBatchAndWait(t *testing.T) {
 	// Create test data
-	batch := New(NewConstantConfig(&ConfigValues{}))
+	batch := New[any](NewConstantConfig(&ConfigValues{}))
 	src := &testSource{
-		Items:   []interface{}{1, 2, 3},
+		Items:   []any{1, 2, 3},
 		WithErr: errors.New("source error"),
 	}
 
@@ -85,7 +85,7 @@ func TestRunBatchAndWait(t *testing.T) {
 	proc := &countProcessor{count: &count}
 
 	// Run the batch and collect errors
-	errs := RunBatchAndWait(context.Background(), batch, src, proc)
+	errs := RunBatchAndWait[any](context.Background(), batch, src, proc)
 
 	// Verify processing occurred
 	if atomic.LoadUint32(&count) != 3 {
@@ -101,23 +101,23 @@ func TestRunBatchAndWait(t *testing.T) {
 func TestExecuteBatches(t *testing.T) {
 	t.Run("all valid configs", func(t *testing.T) {
 		// Create multiple batches with sources and processors
-		batch1 := New(NewConstantConfig(&ConfigValues{}))
-		src1 := &testSource{Items: []interface{}{1, 2, 3}}
+		batch1 := New[any](NewConstantConfig(&ConfigValues{}))
+		src1 := &testSource{Items: []any{1, 2, 3}}
 		var count1 uint32
 		proc1 := &countProcessor{count: &count1}
 
-		batch2 := New(NewConstantConfig(&ConfigValues{}))
+		batch2 := New[any](NewConstantConfig(&ConfigValues{}))
 		src2 := &testSource{
-			Items:   []interface{}{4, 5},
+			Items:   []any{4, 5},
 			WithErr: errors.New("source 2 error"),
 		}
 		var count2 uint32
 		proc2 := &countProcessor{count: &count2}
 
 		// Configure the batches
-		configs := []*BatchConfig{
-			{B: batch1, S: src1, P: []Processor{proc1}},
-			{B: batch2, S: src2, P: []Processor{proc2}},
+		configs := []*BatchConfig[any]{
+			{B: batch1, S: src1, P: []Processor[any]{proc1}},
+			{B: batch2, S: src2, P: []Processor[any]{proc2}},
 		}
 
 		// Execute all batches
@@ -139,20 +139,20 @@ func TestExecuteBatches(t *testing.T) {
 	})
 
 	t.Run("nil config element", func(t *testing.T) {
-		batch1 := New(NewConstantConfig(&ConfigValues{}))
-		src1 := &testSource{Items: []interface{}{1, 2, 3}}
+		batch1 := New[any](NewConstantConfig(&ConfigValues{}))
+		src1 := &testSource{Items: []any{1, 2, 3}}
 		var count1 uint32
 		proc1 := &countProcessor{count: &count1}
 
-		batch2 := New(NewConstantConfig(&ConfigValues{}))
-		src2 := &testSource{Items: []interface{}{4}}
+		batch2 := New[any](NewConstantConfig(&ConfigValues{}))
+		src2 := &testSource{Items: []any{4}}
 		var count2 uint32
 		proc2 := &countProcessor{count: &count2}
 
-		configs := []*BatchConfig{
-			{B: batch1, S: src1, P: []Processor{proc1}},
+		configs := []*BatchConfig[any]{
+			{B: batch1, S: src1, P: []Processor[any]{proc1}},
 			nil,
-			{B: batch2, S: src2, P: []Processor{proc2}},
+			{B: batch2, S: src2, P: []Processor[any]{proc2}},
 		}
 
 		errs := ExecuteBatches(context.Background(), configs...)
@@ -172,20 +172,20 @@ func TestExecuteBatches(t *testing.T) {
 }
 
 func TestExecuteBatches_NilConfig(t *testing.T) {
-	batch1 := New(NewConstantConfig(&ConfigValues{}))
-	src1 := &testSource{Items: []interface{}{1, 2, 3}}
+	batch1 := New[any](NewConstantConfig(&ConfigValues{}))
+	src1 := &testSource{Items: []any{1, 2, 3}}
 	var count1 uint32
 	proc1 := &countProcessor{count: &count1}
 
-	batch2 := New(NewConstantConfig(&ConfigValues{}))
-	src2 := &testSource{Items: []interface{}{4, 5}}
+	batch2 := New[any](NewConstantConfig(&ConfigValues{}))
+	src2 := &testSource{Items: []any{4, 5}}
 	var count2 uint32
 	proc2 := &countProcessor{count: &count2}
 
-	configs := []*BatchConfig{
-		{B: batch1, S: src1, P: []Processor{proc1}},
+	configs := []*BatchConfig[any]{
+		{B: batch1, S: src1, P: []Processor[any]{proc1}},
 		nil,
-		{B: batch2, S: src2, P: []Processor{proc2}},
+		{B: batch2, S: src2, P: []Processor[any]{proc2}},
 	}
 
 	errs := ExecuteBatches(context.Background(), configs...)
@@ -209,18 +209,18 @@ type countProcessor struct {
 	count *uint32
 }
 
-func (p *countProcessor) Process(ctx context.Context, items []*Item) ([]*Item, error) {
+func (p *countProcessor) Process(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
 	atomic.AddUint32(p.count, uint32(len(items)))
 	return items, nil
 }
 
 type testSource struct {
-	Items   []interface{}
+	Items   []any
 	WithErr error
 }
 
-func (s *testSource) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	out := make(chan interface{})
+func (s *testSource) Read(ctx context.Context) (<-chan any, <-chan error) {
+	out := make(chan any)
 	errs := make(chan error, 1)
 	go func() {
 		defer close(out)

--- a/batch/maxtime_test.go
+++ b/batch/maxtime_test.go
@@ -23,16 +23,16 @@ func TestMaxTimeIdle(t *testing.T) {
 		MaxTime:  100 * time.Millisecond,
 	})
 
-	b := batch.New(cfg)
+	b := batch.New[any](cfg)
 
 	// Input channel
-	input := make(chan interface{})
-	src := &source.Channel{Input: input}
+	input := make(chan any)
+	src := &source.Channel[any]{Input: input}
 
 	// Counter processor
 	var processedCount int32
-	proc := &processor.Transform{
-		Func: func(data interface{}) (interface{}, error) {
+	proc := &processor.Transform[any]{
+		Func: func(data any) (any, error) {
 			atomic.AddInt32(&processedCount, 1)
 			return data, nil
 		},

--- a/batch/testhelpers_test.go
+++ b/batch/testhelpers_test.go
@@ -11,13 +11,13 @@ import (
 
 // testSource emits predefined items with optional delay and final error.
 type testSource struct {
-	Items   []interface{}
+	Items   []any
 	Delay   time.Duration
 	WithErr error
 }
 
-func (s *testSource) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	out := make(chan interface{})
+func (s *testSource) Read(ctx context.Context) (<-chan any, <-chan error) {
+	out := make(chan any)
 	errs := make(chan error, 1)
 	go func() {
 		defer close(out)
@@ -46,7 +46,7 @@ type countProcessor struct {
 	processorErr error
 }
 
-func (p *countProcessor) Process(ctx context.Context, items []*Item) ([]*Item, error) {
+func (p *countProcessor) Process(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
 	if p.delay > 0 {
 		time.Sleep(p.delay)
 	}
@@ -64,7 +64,7 @@ type errorPerItemProcessor struct {
 	FailEvery int
 }
 
-func (p *errorPerItemProcessor) Process(ctx context.Context, items []*Item) ([]*Item, error) {
+func (p *errorPerItemProcessor) Process(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
 	for i, item := range items {
 		if p.FailEvery > 0 && (i%p.FailEvery) == 0 {
 			item.Error = fmt.Errorf("fail item %d", item.ID)
@@ -75,10 +75,10 @@ func (p *errorPerItemProcessor) Process(ctx context.Context, items []*Item) ([]*
 
 // transformProcessor modifies item data with transformFn.
 type transformProcessor struct {
-	transformFn func(interface{}) interface{}
+	transformFn func(any) any
 }
 
-func (p *transformProcessor) Process(ctx context.Context, items []*Item) ([]*Item, error) {
+func (p *transformProcessor) Process(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
 	select {
 	case <-ctx.Done():
 		return items, ctx.Err()
@@ -95,11 +95,11 @@ func (p *transformProcessor) Process(ctx context.Context, items []*Item) ([]*Ite
 
 // filterProcessor only keeps items for which filterFn returns true.
 type filterProcessor struct {
-	filterFn func(interface{}) bool
+	filterFn func(any) bool
 }
 
-func (p *filterProcessor) Process(ctx context.Context, items []*Item) ([]*Item, error) {
-	var result []*Item
+func (p *filterProcessor) Process(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
+	var result []*Item[any]
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
@@ -119,10 +119,10 @@ func (p *filterProcessor) Process(ctx context.Context, items []*Item) ([]*Item, 
 
 // testProcessor calls processFn for processing items.
 type testProcessor struct {
-	processFn func(context.Context, []*Item) ([]*Item, error)
+	processFn func(context.Context, []*Item[any]) ([]*Item[any], error)
 }
 
-func (p *testProcessor) Process(ctx context.Context, items []*Item) ([]*Item, error) {
+func (p *testProcessor) Process(ctx context.Context, items []*Item[any]) ([]*Item[any], error) {
 	if p.processFn != nil {
 		return p.processFn(ctx, items)
 	}

--- a/doc.go
+++ b/doc.go
@@ -9,12 +9,12 @@
 // Basic usage ties these packages together:
 //
 //	cfg := batch.NewConstantConfig(&batch.ConfigValues{MinItems: 1})
-//	b := batch.New(cfg)
-//	ch := make(chan interface{}, 1)
+//	b := batch.New[string](cfg)
+//	ch := make(chan string, 1)
 //	ch <- "hello"
 //	close(ch)
-//	src := &source.Channel{Input: ch}
-//	proc := &processor.Transform{Func: func(v interface{}) (interface{}, error) {
+//	src := &source.Channel[string]{Input: ch}
+//	proc := &processor.Transform[string]{Func: func(v string) (string, error) {
 //	    fmt.Println(v)
 //	    return v, nil
 //	}}

--- a/example_test.go
+++ b/example_test.go
@@ -11,14 +11,14 @@ import (
 
 func Example() {
 	cfg := batch.NewConstantConfig(&batch.ConfigValues{MinItems: 1})
-	b := batch.New(cfg)
+	b := batch.New[string](cfg)
 
-	ch := make(chan interface{}, 1)
+	ch := make(chan string, 1)
 	ch <- "hello"
 	close(ch)
 
-	src := &source.Channel{Input: ch}
-	proc := &processor.Transform{Func: func(v interface{}) (interface{}, error) {
+	src := &source.Channel[string]{Input: ch}
+	proc := &processor.Transform[string]{Func: func(v string) (string, error) {
 		fmt.Println(v)
 		return v, nil
 	}}

--- a/processor/channel.go
+++ b/processor/channel.go
@@ -9,15 +9,15 @@ import (
 // Channel is a Processor that sends the Data field of each item to an output
 // channel. Items with existing errors are ignored. The channel is not closed by
 // the processor.
-type Channel struct {
+type Channel[T any] struct {
 	// Output is the channel that receives each item's Data value.
 	// If nil, the processor does nothing.
-	Output chan<- interface{}
+	Output chan<- T
 }
 
 // Process implements the Processor interface by forwarding item data to the
 // Output channel until the context is canceled.
-func (p *Channel) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *Channel[T]) Process(ctx context.Context, items []*batch.Item[T]) ([]*batch.Item[T], error) {
 	if len(items) == 0 || p.Output == nil {
 		return items, nil
 	}

--- a/processor/channel_test.go
+++ b/processor/channel_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestChannel_Process(t *testing.T) {
 	t.Run("writes data to output channel", func(t *testing.T) {
-		out := make(chan interface{}, 3)
-		processor := &Channel{Output: out}
+		out := make(chan any, 3)
+		processor := &Channel[any]{Output: out}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "a"},
 			{ID: 2, Data: "b"},
 			{ID: 3, Data: "c"},
@@ -31,7 +31,7 @@ func TestChannel_Process(t *testing.T) {
 		}
 
 		close(out)
-		var collected []interface{}
+		var collected []any
 		for v := range out {
 			collected = append(collected, v)
 		}
@@ -48,12 +48,12 @@ func TestChannel_Process(t *testing.T) {
 	})
 
 	t.Run("respects context cancellation", func(t *testing.T) {
-		out := make(chan interface{})
-		processor := &Channel{Output: out}
+		out := make(chan any)
+		processor := &Channel[any]{Output: out}
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		items := []*batch.Item{{ID: 1, Data: "test"}}
+		items := []*batch.Item[any]{{ID: 1, Data: "test"}}
 		_, err := processor.Process(ctx, items)
 
 		if err != context.Canceled {
@@ -69,8 +69,8 @@ func TestChannel_Process(t *testing.T) {
 	})
 
 	t.Run("handles nil output channel", func(t *testing.T) {
-		processor := &Channel{Output: nil}
-		items := []*batch.Item{{ID: 1, Data: "data"}}
+		processor := &Channel[any]{Output: nil}
+		items := []*batch.Item[any]{{ID: 1, Data: "data"}}
 		ctx := context.Background()
 
 		result, err := processor.Process(ctx, items)
@@ -84,10 +84,10 @@ func TestChannel_Process(t *testing.T) {
 	})
 
 	t.Run("skips items with existing errors", func(t *testing.T) {
-		out := make(chan interface{}, 2)
-		processor := &Channel{Output: out}
+		out := make(chan any, 2)
+		processor := &Channel[any]{Output: out}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "a", Error: errors.New("fail")},
 			{ID: 2, Data: "b"},
 		}
@@ -99,7 +99,7 @@ func TestChannel_Process(t *testing.T) {
 		}
 		close(out)
 
-		var collected []interface{}
+		var collected []any
 		for v := range out {
 			collected = append(collected, v)
 		}
@@ -110,11 +110,11 @@ func TestChannel_Process(t *testing.T) {
 	})
 
 	t.Run("handles empty slice", func(t *testing.T) {
-		out := make(chan interface{}, 1)
-		processor := &Channel{Output: out}
+		out := make(chan any, 1)
+		processor := &Channel[any]{Output: out}
 		ctx := context.Background()
 
-		result, err := processor.Process(ctx, []*batch.Item{})
+		result, err := processor.Process(ctx, []*batch.Item[any]{})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/processor/doc.go
+++ b/processor/doc.go
@@ -12,14 +12,11 @@
 //
 // Basic usage of the Transform processor:
 //
-//	p := &Transform{Func: func(v interface{}) (interface{}, error) {
-//	    if n, ok := v.(int); ok {
-//	        return n * 2, nil
-//	    }
-//	    return v, nil
+//	p := &Transform[int]{Func: func(v int) (int, error) {
+//	    return v * 2, nil
 //	}}
 //
-//	items := []*batch.Item{{Data: 1}, {Data: 2}}
+//	items := []*batch.Item[int]{{Data: 1}, {Data: 2}}
 //	res, _ := p.Process(context.Background(), items)
 //	fmt.Println(res[0].Data, res[1].Data)
 //

--- a/processor/error.go
+++ b/processor/error.go
@@ -10,7 +10,7 @@ import (
 // Error is a Processor that marks all incoming items with the given error.
 // It's useful for testing error handling in batch processing pipelines and
 // for simulating scenarios where items fail processing.
-type Error struct {
+type Error[T any] struct {
 	// Err is the error to apply to each item.
 	// If nil, a default "processor error" will be used.
 	Err error
@@ -25,7 +25,7 @@ type Error struct {
 
 // Process implements the Processor interface by marking items with errors
 // according to the configured FailFraction.
-func (p *Error) Process(_ context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *Error[T]) Process(_ context.Context, items []*batch.Item[T]) ([]*batch.Item[T], error) {
 	if len(items) == 0 {
 		return items, nil
 	}

--- a/processor/error_test.go
+++ b/processor/error_test.go
@@ -12,12 +12,12 @@ func TestError_Process(t *testing.T) {
 	t.Run("applies error to all items with default settings", func(t *testing.T) {
 		// Setup
 		customErr := errors.New("custom test error")
-		processor := &Error{
+		processor := &Error[any]{
 			Err:          customErr,
 			FailFraction: 1.0, // Default - apply to all
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "item1"},
 			{ID: 2, Data: "item2"},
 			{ID: 3, Data: "item3"},
@@ -55,12 +55,12 @@ func TestError_Process(t *testing.T) {
 
 	t.Run("uses default error when nil provided", func(t *testing.T) {
 		// Setup
-		processor := &Error{
+		processor := &Error[any]{
 			Err:          nil, // Should use default
 			FailFraction: 1.0,
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "test"},
 		}
 
@@ -78,14 +78,14 @@ func TestError_Process(t *testing.T) {
 
 	t.Run("handles empty items slice", func(t *testing.T) {
 		// Setup
-		processor := &Error{
+		processor := &Error[any]{
 			Err:          errors.New("test"),
 			FailFraction: 1.0,
 		}
 
 		// Execute
 		ctx := context.Background()
-		processedItems, err := processor.Process(ctx, []*batch.Item{})
+		processedItems, err := processor.Process(ctx, []*batch.Item[any]{})
 
 		// Verify
 		if err != nil {
@@ -100,15 +100,15 @@ func TestError_Process(t *testing.T) {
 	t.Run("applies error to fraction of items", func(t *testing.T) {
 		// Setup
 		customErr := errors.New("partial error")
-		processor := &Error{
+		processor := &Error[any]{
 			Err:          customErr,
 			FailFraction: 0.5, // Apply to approximately half
 		}
 
 		// Create 10 items - about 5 should have errors
-		items := make([]*batch.Item, 10)
+		items := make([]*batch.Item[any], 10)
 		for i := 0; i < 10; i++ {
-			items[i] = &batch.Item{ID: uint64(i), Data: i}
+			items[i] = &batch.Item[any]{ID: uint64(i), Data: i}
 		}
 
 		// Execute
@@ -140,12 +140,12 @@ func TestError_Process(t *testing.T) {
 
 	t.Run("applies no errors when fail fraction is zero", func(t *testing.T) {
 		// Setup
-		processor := &Error{
+		processor := &Error[any]{
 			Err:          errors.New("test"),
 			FailFraction: 0, // No errors
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "item1"},
 			{ID: 2, Data: "item2"},
 		}

--- a/processor/example_test.go
+++ b/processor/example_test.go
@@ -9,14 +9,11 @@ import (
 )
 
 func ExampleTransform() {
-	p := &processor.Transform{Func: func(v interface{}) (interface{}, error) {
-		if n, ok := v.(int); ok {
-			return n * 2, nil
-		}
-		return v, nil
+	p := &processor.Transform[int]{Func: func(v int) (int, error) {
+		return v * 2, nil
 	}}
 
-	items := []*batch.Item{{Data: 1}, {Data: 2}}
+	items := []*batch.Item[int]{{Data: 1}, {Data: 2}}
 	res, _ := p.Process(context.Background(), items)
 	fmt.Println(res[0].Data, res[1].Data)
 	// Output:

--- a/processor/filter.go
+++ b/processor/filter.go
@@ -8,15 +8,15 @@ import (
 
 // FilterFunc is a function that decides whether an item should be included in the output.
 // Return true to keep the item, false to filter it out.
-type FilterFunc func(item *batch.Item) bool
+type FilterFunc[T any] func(item *batch.Item[T]) bool
 
 // Filter is a processor that filters items based on a predicate function.
 // It can be used to remove items from the pipeline that don't meet certain criteria.
-type Filter struct {
+type Filter[T any] struct {
 	// Predicate is a function that returns true for items that should be kept
 	// and false for items that should be filtered out.
 	// If nil, no filtering occurs (all items pass through).
-	Predicate FilterFunc
+	Predicate FilterFunc[T]
 
 	// InvertMatch inverts the predicate logic: if true, items matching the predicate
 	// will be removed instead of kept.
@@ -27,13 +27,13 @@ type Filter struct {
 // Process implements the Processor interface by filtering items according to the predicate.
 // Items that don't pass the filter are simply not included in the returned slice.
 // This does not set any errors on items, it just excludes them from further processing.
-func (p *Filter) Process(_ context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *Filter[T]) Process(_ context.Context, items []*batch.Item[T]) ([]*batch.Item[T], error) {
 	if len(items) == 0 || p.Predicate == nil {
 		return items, nil
 	}
 
 	// Pre-allocate with capacity of original slice
-	result := make([]*batch.Item, 0, len(items))
+	result := make([]*batch.Item[T], 0, len(items))
 
 	for _, item := range items {
 		shouldKeep := p.Predicate(item)

--- a/processor/filter_test.go
+++ b/processor/filter_test.go
@@ -10,13 +10,13 @@ import (
 func TestFilter_Process(t *testing.T) {
 	t.Run("keeps items matching predicate", func(t *testing.T) {
 		// Setup - keep only even-numbered IDs
-		processor := &Filter{
-			Predicate: func(item *batch.Item) bool {
+		processor := &Filter[any]{
+			Predicate: func(item *batch.Item[any]) bool {
 				return item.ID%2 == 0 // Keep even IDs
 			},
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "odd"},
 			{ID: 2, Data: "even"},
 			{ID: 3, Data: "odd"},
@@ -45,14 +45,14 @@ func TestFilter_Process(t *testing.T) {
 
 	t.Run("inverts predicate with InvertMatch", func(t *testing.T) {
 		// Setup - remove even-numbered IDs (keep odd)
-		processor := &Filter{
-			Predicate: func(item *batch.Item) bool {
+		processor := &Filter[any]{
+			Predicate: func(item *batch.Item[any]) bool {
 				return item.ID%2 == 0 // Matches even IDs
 			},
 			InvertMatch: true, // But we'll invert to keep odd IDs
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "odd"},
 			{ID: 2, Data: "even"},
 			{ID: 3, Data: "odd"},
@@ -77,11 +77,11 @@ func TestFilter_Process(t *testing.T) {
 
 	t.Run("handles nil predicate", func(t *testing.T) {
 		// Setup - nil predicate should pass all items through
-		processor := &Filter{
+		processor := &Filter[any]{
 			Predicate: nil,
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "item1"},
 			{ID: 2, Data: "item2"},
 		}
@@ -98,15 +98,15 @@ func TestFilter_Process(t *testing.T) {
 
 	t.Run("handles empty items slice", func(t *testing.T) {
 		// Setup
-		processor := &Filter{
-			Predicate: func(item *batch.Item) bool {
+		processor := &Filter[any]{
+			Predicate: func(item *batch.Item[any]) bool {
 				return true // Keep all
 			},
 		}
 
 		// Execute
 		ctx := context.Background()
-		result, err := processor.Process(ctx, []*batch.Item{})
+		result, err := processor.Process(ctx, []*batch.Item[any]{})
 
 		// Verify
 		if err != nil {
@@ -120,13 +120,13 @@ func TestFilter_Process(t *testing.T) {
 
 	t.Run("can filter all items out", func(t *testing.T) {
 		// Setup - filter that rejects everything
-		processor := &Filter{
-			Predicate: func(item *batch.Item) bool {
+		processor := &Filter[any]{
+			Predicate: func(item *batch.Item[any]) bool {
 				return false // Reject all
 			},
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "item1"},
 			{ID: 2, Data: "item2"},
 		}
@@ -143,14 +143,14 @@ func TestFilter_Process(t *testing.T) {
 
 	t.Run("filters based on Data field", func(t *testing.T) {
 		// Setup - keep only items with string Data
-		processor := &Filter{
-			Predicate: func(item *batch.Item) bool {
+		processor := &Filter[any]{
+			Predicate: func(item *batch.Item[any]) bool {
 				_, isString := item.Data.(string)
 				return isString
 			},
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "string data"},    // keep
 			{ID: 2, Data: 42},               // filter out
 			{ID: 3, Data: "another string"}, // keep

--- a/processor/nil.go
+++ b/processor/nil.go
@@ -10,7 +10,7 @@ import (
 // Nil is a Processor that sleeps for the configured duration and does nothing else.
 // It's useful for testing timing behavior and simulating time-consuming operations
 // without actually modifying items.
-type Nil struct {
+type Nil[T any] struct {
 	// Duration specifies how long the processor should sleep before returning.
 	// If zero or negative, the processor will return immediately.
 	Duration time.Duration
@@ -23,7 +23,7 @@ type Nil struct {
 
 // Process implements the Processor interface by waiting for the specified duration
 // and returning the items unchanged, unless canceled.
-func (p *Nil) Process(ctx context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *Nil[T]) Process(ctx context.Context, items []*batch.Item[T]) ([]*batch.Item[T], error) {
 	if len(items) == 0 || p.Duration <= 0 {
 		return items, nil
 	}

--- a/processor/nil_test.go
+++ b/processor/nil_test.go
@@ -11,9 +11,9 @@ import (
 func TestNil_Process(t *testing.T) {
 	t.Run("returns items unchanged with zero duration", func(t *testing.T) {
 		// Setup
-		processor := &Nil{Duration: 0}
+		processor := &Nil[any]{Duration: 0}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "item1"},
 			{ID: 2, Data: "item2"},
 		}
@@ -55,9 +55,9 @@ func TestNil_Process(t *testing.T) {
 	t.Run("waits for the specified duration", func(t *testing.T) {
 		// Setup
 		duration := 50 * time.Millisecond
-		processor := &Nil{Duration: duration}
+		processor := &Nil[any]{Duration: duration}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "test"},
 		}
 
@@ -80,14 +80,14 @@ func TestNil_Process(t *testing.T) {
 
 	t.Run("handles empty items slice", func(t *testing.T) {
 		// Setup
-		processor := &Nil{
+		processor := &Nil[any]{
 			Duration: 50 * time.Millisecond,
 		}
 
 		// Execute
 		ctx := context.Background()
 		start := time.Now()
-		processedItems, err := processor.Process(ctx, []*batch.Item{})
+		processedItems, err := processor.Process(ctx, []*batch.Item[any]{})
 		elapsed := time.Since(start)
 
 		// Verify
@@ -107,12 +107,12 @@ func TestNil_Process(t *testing.T) {
 
 	t.Run("respects context cancellation", func(t *testing.T) {
 		// Setup
-		processor := &Nil{
+		processor := &Nil[any]{
 			Duration:      1 * time.Second, // Long enough to not complete naturally
 			MarkCancelled: true,
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "item1"},
 			{ID: 2, Data: "item2"},
 		}
@@ -122,14 +122,14 @@ func TestNil_Process(t *testing.T) {
 
 		// Start processing in a goroutine
 		resultCh := make(chan struct {
-			items []*batch.Item
+			items []*batch.Item[any]
 			err   error
 		})
 
 		go func() {
 			items, err := processor.Process(ctx, items)
 			resultCh <- struct {
-				items []*batch.Item
+				items []*batch.Item[any]
 				err   error
 			}{items, err}
 		}()
@@ -157,12 +157,12 @@ func TestNil_Process(t *testing.T) {
 
 	t.Run("respects MarkCancelled=false setting", func(t *testing.T) {
 		// Setup - this time don't mark items as canceled
-		processor := &Nil{
+		processor := &Nil[any]{
 			Duration:      1 * time.Second,
 			MarkCancelled: false,
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "test"},
 		}
 

--- a/processor/transform.go
+++ b/processor/transform.go
@@ -8,14 +8,14 @@ import (
 
 // TransformFunc is a function that transforms an item's Data field.
 // It takes the current Data value and returns the new Data value.
-type TransformFunc func(data interface{}) (interface{}, error)
+type TransformFunc[T any] func(data T) (T, error)
 
 // Transform is a processor that applies a transformation function to each item's Data field.
 // It can be used to convert, modify, or restructure data during batch processing.
-type Transform struct {
+type Transform[T any] struct {
 	// Func is the transformation function to apply to each item's Data field.
 	// If nil, items pass through unchanged.
-	Func TransformFunc
+	Func TransformFunc[T]
 
 	// StopOnError determines whether to stop processing items after a transformation error.
 	// If true, the processor will return an error and stop after the first transformation failure.
@@ -26,7 +26,7 @@ type Transform struct {
 
 // Process implements the Processor interface by applying the transformation function
 // to each item's Data field.
-func (p *Transform) Process(_ context.Context, items []*batch.Item) ([]*batch.Item, error) {
+func (p *Transform[T]) Process(_ context.Context, items []*batch.Item[T]) ([]*batch.Item[T], error) {
 	if len(items) == 0 || p.Func == nil {
 		return items, nil
 	}

--- a/processor/transform_test.go
+++ b/processor/transform_test.go
@@ -13,8 +13,8 @@ import (
 func TestTransform_Process(t *testing.T) {
 	t.Run("transforms data successfully", func(t *testing.T) {
 		// Setup - double all integer values
-		processor := &Transform{
-			Func: func(data interface{}) (interface{}, error) {
+		processor := &Transform[any]{
+			Func: func(data any) (any, error) {
 				if val, ok := data.(int); ok {
 					return val * 2, nil
 				}
@@ -22,7 +22,7 @@ func TestTransform_Process(t *testing.T) {
 			},
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: 5},
 			{ID: 2, Data: 10},
 			{ID: 3, Data: "not an int"},
@@ -57,8 +57,8 @@ func TestTransform_Process(t *testing.T) {
 
 	t.Run("handles transformation errors with StopOnError=false", func(t *testing.T) {
 		// Setup - convert to int but fail on non-integers
-		processor := &Transform{
-			Func: func(data interface{}) (interface{}, error) {
+		processor := &Transform[any]{
+			Func: func(data any) (any, error) {
 				if str, ok := data.(string); ok {
 					val, err := strconv.Atoi(str)
 					if err != nil {
@@ -71,7 +71,7 @@ func TestTransform_Process(t *testing.T) {
 			StopOnError: false, // Continue after errors
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "123"},       // Should convert to 123
 			{ID: 2, Data: "not a num"}, // Should error
 			{ID: 3, Data: "456"},       // Should convert to 456
@@ -108,8 +108,8 @@ func TestTransform_Process(t *testing.T) {
 	t.Run("stops on first error with StopOnError=true", func(t *testing.T) {
 		// Setup
 		testErr := errors.New("transformation failed")
-		processor := &Transform{
-			Func: func(data interface{}) (interface{}, error) {
+		processor := &Transform[any]{
+			Func: func(data any) (any, error) {
 				if val, ok := data.(int); ok {
 					if val == 2 {
 						return nil, testErr
@@ -121,7 +121,7 @@ func TestTransform_Process(t *testing.T) {
 			StopOnError: true, // Stop on first error
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: 1}, // Should be doubled to 2
 			{ID: 2, Data: 2}, // Should cause error
 			{ID: 3, Data: 3}, // Should not be processed
@@ -154,8 +154,8 @@ func TestTransform_Process(t *testing.T) {
 
 	t.Run("skips items with existing errors", func(t *testing.T) {
 		// Setup
-		processor := &Transform{
-			Func: func(data interface{}) (interface{}, error) {
+		processor := &Transform[any]{
+			Func: func(data any) (any, error) {
 				if val, ok := data.(int); ok {
 					return val * 2, nil
 				}
@@ -164,7 +164,7 @@ func TestTransform_Process(t *testing.T) {
 		}
 
 		existingErr := errors.New("existing error")
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: 10, Error: existingErr}, // Already has error, should be skipped
 			{ID: 2, Data: 20},                     // Should be doubled
 		}
@@ -186,11 +186,11 @@ func TestTransform_Process(t *testing.T) {
 
 	t.Run("handles nil transform function", func(t *testing.T) {
 		// Setup - nil function should pass through
-		processor := &Transform{
+		processor := &Transform[any]{
 			Func: nil,
 		}
 
-		items := []*batch.Item{
+		items := []*batch.Item[any]{
 			{ID: 1, Data: "test"},
 		}
 
@@ -210,15 +210,15 @@ func TestTransform_Process(t *testing.T) {
 
 	t.Run("handles empty items slice", func(t *testing.T) {
 		// Setup
-		processor := &Transform{
-			Func: func(data interface{}) (interface{}, error) {
+		processor := &Transform[any]{
+			Func: func(data any) (any, error) {
 				return "transformed", nil
 			},
 		}
 
 		// Execute
 		ctx := context.Background()
-		result, err := processor.Process(ctx, []*batch.Item{})
+		result, err := processor.Process(ctx, []*batch.Item[any]{})
 
 		// Verify
 		if err != nil {

--- a/source/channel.go
+++ b/source/channel.go
@@ -10,10 +10,10 @@ const defaultChannelBuffer = 100
 
 // Channel is a Source that reads from an input channel until it's closed.
 // It simplifies using an existing channel as a data source for batch processing.
-type Channel struct {
+type Channel[T any] struct {
 	// Input is the channel from which this source will read data.
 	// The Channel source will not close this channel.
-	Input <-chan interface{}
+	Input <-chan T
 	// BufferSize controls the size of the output buffer (default: 100)
 	BufferSize int
 }
@@ -23,13 +23,13 @@ type Channel struct {
 //
 // The returned channels are always created (never nil) and always closed properly
 // when the source is done providing data or context is canceled.
-func (s *Channel) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
+func (s *Channel[T]) Read(ctx context.Context) (<-chan T, <-chan error) {
 	bufSize := defaultChannelBuffer
 	if s.BufferSize > 0 {
 		bufSize = s.BufferSize
 	}
 
-	out := make(chan interface{}, bufSize)
+	out := make(chan T, bufSize)
 	errs := make(chan error)
 
 	go func() {

--- a/source/channel_test.go
+++ b/source/channel_test.go
@@ -10,21 +10,21 @@ import (
 func TestChannel_Read(t *testing.T) {
 	t.Run("normal operation", func(t *testing.T) {
 		// Setup
-		testData := []interface{}{1, "two", 3.0, []int{4}}
-		in := make(chan interface{}, len(testData))
+		testData := []any{1, "two", 3.0, []int{4}}
+		in := make(chan any, len(testData))
 		for _, item := range testData {
 			in <- item
 		}
 		close(in)
 
-		source := &Channel{Input: in}
+		source := &Channel[any]{Input: in}
 		ctx := context.Background()
 
 		// Execute
 		out, errs := source.Read(ctx)
 
 		// Collect results
-		var results []interface{}
+		var results []any
 		var errors []error
 
 		// Collect all data first
@@ -64,10 +64,10 @@ func TestChannel_Read(t *testing.T) {
 
 	t.Run("respects context cancellation", func(t *testing.T) {
 		// Setup an infinite channel that would hang without cancellation
-		in := make(chan interface{})
+		in := make(chan any)
 		defer close(in)
 
-		source := &Channel{Input: in}
+		source := &Channel[any]{Input: in}
 		ctx, cancel := context.WithCancel(context.Background())
 
 		// Execute
@@ -104,7 +104,7 @@ func TestChannel_Read(t *testing.T) {
 
 	t.Run("handles nil input", func(t *testing.T) {
 		// Setup source with nil input
-		source := &Channel{Input: nil}
+		source := &Channel[any]{Input: nil}
 		ctx := context.Background()
 
 		// Execute
@@ -138,8 +138,8 @@ func TestChannel_Read(t *testing.T) {
 
 	t.Run("respects buffer size", func(t *testing.T) {
 		bufSize := 5
-		source := &Channel{
-			Input:      make(chan interface{}),
+		source := &Channel[any]{
+			Input:      make(chan any),
 			BufferSize: bufSize,
 		}
 

--- a/source/doc.go
+++ b/source/doc.go
@@ -10,12 +10,12 @@
 //
 // Basic usage of the Channel source:
 //
-//	input := make(chan interface{}, 2)
-//	input <- "a"
-//	input <- "b"
+//	input := make(chan int, 2)
+//	input <- 1
+//	input <- 2
 //	close(input)
 //
-//	src := &Channel{Input: input}
+//	src := &Channel[int]{Input: input}
 //	out, errs := src.Read(context.Background())
 //	for item := range out {
 //	    fmt.Println(item)
@@ -25,6 +25,6 @@
 //
 // Output:
 //
-//	a
-//	b
+//	1
+//	2
 package source

--- a/source/error.go
+++ b/source/error.go
@@ -11,7 +11,10 @@ const defaultErrorBuffer = 10
 // Error is a Source that only emits errors from a channel and provides no data.
 // It is useful for testing error handling in batch processing pipelines and
 // for representing error-only streams.
-type Error struct {
+//
+// The type parameter T exists to satisfy the Source[T] interface. Since this
+// source never emits data items, T is never used in produced values.
+type Error[T any] struct {
 	// Errs is the channel from which this source will read errors.
 	// The Error source will not close this channel.
 	Errs <-chan error
@@ -25,8 +28,8 @@ type Error struct {
 // The returned channels are always created (never nil) and always closed properly
 // when the source is done providing errors or context is canceled.
 // The output channel is always empty, as this source produces only errors.
-func (s *Error) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	out := make(chan interface{})
+func (s *Error[T]) Read(ctx context.Context) (<-chan T, <-chan error) {
+	out := make(chan T)
 
 	bufSize := defaultErrorBuffer
 	if s.BufferSize > 0 {

--- a/source/error_test.go
+++ b/source/error_test.go
@@ -22,14 +22,14 @@ func TestError_Read(t *testing.T) {
 		}
 		close(errCh)
 
-		source := &Error{Errs: errCh}
+		source := &Error[any]{Errs: errCh}
 		ctx := context.Background()
 
 		// Execute
 		out, errs := source.Read(ctx)
 
 		// Collect results
-		var data []interface{}
+		var data []any
 		var collectedErrors []error
 
 		// Create a timeout to prevent hanging if channels don't close
@@ -90,7 +90,7 @@ func TestError_Read(t *testing.T) {
 		errCh <- errors.New("another error")
 		close(errCh)
 
-		source := &Error{Errs: errCh}
+		source := &Error[any]{Errs: errCh}
 		ctx := context.Background()
 
 		// Execute
@@ -113,7 +113,7 @@ func TestError_Read(t *testing.T) {
 		errCh := make(chan error)
 		defer close(errCh)
 
-		source := &Error{Errs: errCh}
+		source := &Error[any]{Errs: errCh}
 		ctx, cancel := context.WithCancel(context.Background())
 
 		// Execute
@@ -150,7 +150,7 @@ func TestError_Read(t *testing.T) {
 
 	t.Run("handles nil error channel", func(t *testing.T) {
 		// Setup
-		source := &Error{Errs: nil}
+		source := &Error[any]{Errs: nil}
 		ctx := context.Background()
 
 		// Execute
@@ -182,7 +182,7 @@ func TestError_Read(t *testing.T) {
 
 	t.Run("respects buffer size", func(t *testing.T) {
 		bufSize := 5
-		source := &Error{
+		source := &Error[any]{
 			Errs:       make(chan error),
 			BufferSize: bufSize,
 		}

--- a/source/example_test.go
+++ b/source/example_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func ExampleChannel() {
-	input := make(chan interface{}, 2)
+	input := make(chan any, 2)
 	input <- "a"
 	input <- "b"
 	close(input)
 
-	src := &source.Channel{Input: input}
+	src := &source.Channel[any]{Input: input}
 	out, errs := src.Read(context.Background())
 	for item := range out {
 		fmt.Println(item)

--- a/source/example_test.go
+++ b/source/example_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func ExampleChannel() {
-	input := make(chan any, 2)
+	input := make(chan string, 2)
 	input <- "a"
 	input <- "b"
 	close(input)
 
-	src := &source.Channel[any]{Input: input}
+	src := &source.Channel[string]{Input: input}
 	out, errs := src.Read(context.Background())
 	for item := range out {
 		fmt.Println(item)

--- a/source/nil.go
+++ b/source/nil.go
@@ -7,7 +7,7 @@ import (
 
 // Nil is a Source that does nothing but sleeps for a given duration before closing.
 // It is useful for testing shutdown sequences and empty pipeline behavior.
-type Nil struct {
+type Nil[T any] struct {
 	// Duration specifies how long the source will wait before closing its channels.
 	// If zero, it will close immediately.
 	Duration time.Duration
@@ -19,8 +19,8 @@ type Nil struct {
 //
 // The returned channels are always created (never nil) and always closed properly
 // when the source completes waiting or context is canceled.
-func (s *Nil) Read(ctx context.Context) (<-chan interface{}, <-chan error) {
-	out := make(chan interface{})
+func (s *Nil[T]) Read(ctx context.Context) (<-chan T, <-chan error) {
+	out := make(chan T)
 	errs := make(chan error)
 
 	go func() {

--- a/source/nil_test.go
+++ b/source/nil_test.go
@@ -9,7 +9,7 @@ import (
 func TestNil_Read(t *testing.T) {
 	t.Run("closes immediately with zero duration", func(t *testing.T) {
 		// Setup
-		source := &Nil{Duration: 0}
+		source := &Nil[any]{Duration: 0}
 		ctx := context.Background()
 
 		// Execute
@@ -42,7 +42,7 @@ func TestNil_Read(t *testing.T) {
 	t.Run("closes after specified duration", func(t *testing.T) {
 		// Setup
 		duration := 50 * time.Millisecond
-		source := &Nil{Duration: duration}
+		source := &Nil[any]{Duration: duration}
 		ctx := context.Background()
 
 		// Execute
@@ -86,7 +86,7 @@ func TestNil_Read(t *testing.T) {
 
 	t.Run("respects context cancellation", func(t *testing.T) {
 		// Setup
-		source := &Nil{Duration: 10 * time.Second} // Long enough to not complete
+		source := &Nil[any]{Duration: 10 * time.Second} // Long enough to not complete
 		ctx, cancel := context.WithCancel(context.Background())
 
 		// Execute
@@ -121,7 +121,7 @@ func TestNil_Read(t *testing.T) {
 
 	t.Run("negative duration treated as zero", func(t *testing.T) {
 		// Setup
-		source := &Nil{Duration: -10 * time.Millisecond}
+		source := &Nil[any]{Duration: -10 * time.Millisecond}
 		ctx := context.Background()
 
 		// Execute
@@ -153,14 +153,14 @@ func TestNil_Read(t *testing.T) {
 
 	t.Run("emits no data or errors", func(t *testing.T) {
 		// Setup
-		source := &Nil{Duration: 10 * time.Millisecond}
+		source := &Nil[any]{Duration: 10 * time.Millisecond}
 		ctx := context.Background()
 
 		// Execute
 		out, errs := source.Read(ctx)
 
 		// Collect results
-		var data []interface{}
+		var data []any
 		var errors []error
 
 		// Wait for channels to close


### PR DESCRIPTION
## Summary
- migrate `batch`, `source`, and `processor` public APIs to generics (`Batch[T]`, `Item[T]`, `Source[T]`, `Processor[T]`)
- update built-in sources/processors and helper APIs (`RunBatchAndWait[T]`, `BatchConfig[T]`, `ExecuteBatches[T]`)
- migrate tests/examples/docs to typed usage and normalize `any` style
- add v0.5.0 changelog entry with explicit migration notes, including homogeneous `ExecuteBatches[T]` behavior and type-changing pipeline guidance

## Validation
- `/Users/vaughn/go/bin/goimports -w $(rg --files --glob '*.go')`
- `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
- `go vet ./...`
- `/Users/vaughn/go/bin/golangci-lint run --timeout=3m`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wide-reaching breaking changes to all public interfaces and built-in implementations; downstream users must update type parameters and any custom `Source`/`Processor` implementations to compile.
> 
> **Overview**
> **Hard-breaking API migration to generics across the library.** Core types and interfaces are now parameterized (`Batch[T]`, `Item[T]`, `Source[T]`, `Processor[T]`), with `Source.Read` returning `<-chan T` and processors operating on `[]*Item[T]`.
> 
> All built-in sources/processors and helper utilities were updated to the typed API (`RunBatchAndWait[T]`, `BatchConfig[T]`, `ExecuteBatches[T]`), and the full docs/README/examples/tests were rewritten to use explicit type parameters (often `any`) with new v0.5.0 changelog + migration notes (including `ExecuteBatches` now requiring a single shared `T` per call).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b625e7b647d9a7bf199eac3221bb9945980572a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->