### PR TITLE
ci: update workflow for latest Go versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,22 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.18.x', '1.19.x', '1.20.x', '1.21.x']
+        go-version: ['1.25.x', '1.26.x']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
 
     - name: Install dependencies
       run: |
-        go get -t -v ./...
-        # Install golangci-lint (modern replacement for gometalinter)
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
+        go mod download
+        # Install golangci-lint.
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
 
     - name: Check gofmt
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This release introduces a hard switch to generics across the public API.
 - **BREAKING:** `Source.Read` now uses typed output channels: `Read(ctx) (<-chan T, <-chan error)`.
 - **BREAKING:** `Processor.Process` now uses typed items: `Process(ctx, []*Item[T]) ([]*Item[T], error)`.
 - **BREAKING:** Built-in sources and processors now require explicit type parameters (for example, `source.Channel[int]` and `processor.Transform[string]`).
-- CI now runs against the latest Go majors (`1.25.x` and `1.26.x`) and uses current GitHub Actions setup-go/checkout versions.
+- CI: Test against Go 1.25.x and 1.26.x and use `actions/checkout@v4` and `actions/setup-go@v5`.
 - Updated helper APIs to generics:
   - `RunBatchAndWait[T]`
   - `BatchConfig[T]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This release introduces a hard switch to generics across the public API.
 - **BREAKING:** `Source.Read` now uses typed output channels: `Read(ctx) (<-chan T, <-chan error)`.
 - **BREAKING:** `Processor.Process` now uses typed items: `Process(ctx, []*Item[T]) ([]*Item[T], error)`.
 - **BREAKING:** Built-in sources and processors now require explicit type parameters (for example, `source.Channel[int]` and `processor.Transform[string]`).
+- CI now runs against the latest Go majors (`1.25.x` and `1.26.x`) and uses current GitHub Actions setup-go/checkout versions.
 - Updated helper APIs to generics:
   - `RunBatchAndWait[T]`
   - `BatchConfig[T]`


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to test Go 1.25.x and 1.26.x
- update actions/checkout to v4 and actions/setup-go to v5
- bump golangci-lint install version to v1.64.8
- add a changelog note for CI Go-version updates

## Validation
- go test ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes (Go version matrix, GitHub Actions versions, linter install); low risk beyond potential CI breakage if new toolchain versions expose new failures.
> 
> **Overview**
> Updates the GitHub Actions Go workflow to test only Go `1.25.x` and `1.26.x`, and upgrades CI actions to `actions/checkout@v4` and `actions/setup-go@v5`.
> 
> Replaces `go get -t` with `go mod download` for dependency setup and bumps the installed `golangci-lint` version to `v1.64.8`, with a changelog entry noting the CI Go-version/action updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c54d2b2f54f2dd47214bb7533dd56e2a6e5a374b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->