### PR TITLE
ci: upgrade golangci-lint v1.64.8 → v2.12.2 and document install

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         go mod download
         # Install golangci-lint.
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
 
     - name: Check gofmt
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         go mod download
         # Install golangci-lint.
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
 
     - name: Check gofmt
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 - Run tests with race detection and coverage: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
 - Basic lint: `go vet ./...`
 - Full lint: `golangci-lint run --timeout=3m`
-- Install golangci-lint (v2.12.2, matching CI): `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2`
+- Install golangci-lint (v2.12.2, matching CI): `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2`
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 - Run tests with race detection and coverage: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
 - Basic lint: `go vet ./...`
 - Full lint: `golangci-lint run --timeout=3m`
+- Install golangci-lint (v2.12.2, matching CI): `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2`
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 - Run tests with race detection and coverage: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
 - Basic lint: `go vet ./...`
 - Full lint: `golangci-lint run --timeout=3m`
-- Install golangci-lint (v2.12.2, matching CI): `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2`
+- Install golangci-lint (v2.12.2, matching CI): `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2`
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ GoBatch is a Go library for batch data processing. It provides infrastructure fo
 - Run tests with race detection and coverage: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
 - Basic lint: `go vet ./...`
 - Full lint: `golangci-lint run --timeout=3m`
+- Install golangci-lint (v2.12.2, matching CI): `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2`
 
 ## Code Standards
 - Follow Go best practices and idiomatic Go patterns


### PR DESCRIPTION
## Summary

Upgrades golangci-lint from **v1.64.8 → v2.12.2** in CI, and documents the install command in `CLAUDE.md` / `AGENTS.md`.

## Why

- **v1.64.8 is the final v1 release — v1 is EOL.** v2 is the maintained line; v2.12.2 is the current latest.
- Low-risk here: master lints **clean (0 issues)** under v2.12.2 with v2's default linter set, so no `.golangci.yml` and no code changes are needed.

## Changes

- **`.github/workflows/go.yml`**: install `v2.12.2` (was `v1.64.8`) and fetch `install.sh` from `HEAD` instead of the stale `master` branch (golangci-lint renamed its default branch). The `golangci-lint run --timeout=3m` step is unchanged — `--timeout` is still a valid flag in v2.
- **`CLAUDE.md` / `AGENTS.md`**: add the install command, pinned to the CI version, so contributors run the same linter locally (it was referenced but never documented how to install).

## Verification

`golangci-lint v2.12.2 run --timeout=3m` → **0 issues** on master · `go build` / `go vet` / `gofmt -l` / `go test` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
