### PR TITLE
ci: drop dead travis-test branch from push trigger

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ master, travis-test ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
## Summary

`.github/workflows/go.yml` still listed `travis-test` in its `push` trigger branches — a relic of the Travis CI era. The Travis config was removed in #11 (April 2025) when CI moved to GitHub Actions + Codecov, and the `travis-test` branch no longer exists on origin, so the entry is dead config.

## Change

One line: `branches: [ master, travis-test ]` → `branches: [ master ]` in the `push` trigger. No job, matrix, or step changes.

## Context

Found while confirming the repo no longer uses Travis (the stale Travis CI GitHub app installation is being removed from account integrations separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)